### PR TITLE
Adds: subscription management with stripe

### DIFF
--- a/buy-me-coffee.php
+++ b/buy-me-coffee.php
@@ -40,11 +40,16 @@ if (!defined('BUYMECOFFEE_VERSION')) {
     define('BUYMECOFFEE_DIR', plugin_dir_path(__FILE__));
     define('BUYMECOFFEE_UPLOAD_DIR', '/buy-me-coffee');
     define('BUYMECOFFEE_PRODUCTION', 'yes');
+    define('BUYMECOFFEE_DB_VERSION', '1.3');
 
     class BuyMeCoffee
     {
         public function boot()
         {
+            // DB version check — runs on every plugins_loaded to apply schema updates for existing installs
+            require_once BUYMECOFFEE_DIR . 'includes/Classes/Activator.php';
+            (new \BuyMeCoffee\Classes\Activator())->maybeRunMigrations();
+
             if (is_admin()) {
                 $this->adminHooks();
             }
@@ -116,6 +121,7 @@ if (!defined('BUYMECOFFEE_VERSION')) {
 
             //payment methods init
             require BUYMECOFFEE_DIR . 'includes/Builder/Methods/BaseMethods.php';
+            require BUYMECOFFEE_DIR . 'includes/Builder/Methods/Stripe/StripeSubscriptions.php';
             require BUYMECOFFEE_DIR . 'includes/Builder/Methods/Stripe/Stripe.php';
             require BUYMECOFFEE_DIR . 'includes/Builder/Methods/PayPal/PayPal.php';
             new \BuyMeCoffee\Builder\Methods\PayPal\PayPal();
@@ -167,6 +173,7 @@ if (!defined('BUYMECOFFEE_VERSION')) {
         require_once(BUYMECOFFEE_DIR . 'includes/Classes/Activator.php');
         $activator = new \BuyMeCoffee\Classes\Activator();
         $activator->migrateDatabases($newWorkWide);
+        update_option('buymecoffee_db_version', BUYMECOFFEE_DB_VERSION);
     });
 
     // disabled admin-notice on dashboard

--- a/includes/Builder/Methods/Stripe/Stripe.php
+++ b/includes/Builder/Methods/Stripe/Stripe.php
@@ -6,6 +6,7 @@ use BuyMeCoffee\Builder\Methods\BaseMethods;
 use BuyMeCoffee\Classes\Vite;
 use BuyMeCoffee\Helpers\ArrayHelper;
 use BuyMeCoffee\Helpers\PaymentHelper;
+use BuyMeCoffee\Models\Subscriptions;
 use BuyMeCoffee\Models\Supporters;
 use BuyMeCoffee\Models\Transactions;
 
@@ -58,7 +59,17 @@ class Stripe extends BaseMethods
             'public_key' => $keys['public']
         );
 
-        $this->handleInlinePayment($transaction, $paymentArgs, $apiKey);
+        $isRecurring = isset($form_data['is_recurring']) && $form_data['is_recurring'] === 'yes';
+        if ($isRecurring) {
+            $interval        = isset($form_data['recurring_interval']) ? sanitize_text_field($form_data['recurring_interval']) : 'month';
+            $allowedIntervals = ['month', 'year'];
+            if (!in_array($interval, $allowedIntervals, true)) {
+                $interval = 'month';
+            }
+            (new StripeSubscriptions())->createSubscription($transaction, $paymentArgs, $apiKey, $interval);
+        } else {
+            $this->handleInlinePayment($transaction, $paymentArgs, $apiKey);
+        }
     }
 
     public function paymentConfirmation()
@@ -71,9 +82,27 @@ class Stripe extends BaseMethods
                 'message' => __('Payment intent is missing', 'buy-me-coffee')
             ], 400);
         }
+
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Stripe payment confirmation callback
         $intentId = sanitize_text_field(wp_unslash($_REQUEST['intentId']));
+
+        // Primary: if JS passed the local subscription ID, activate it immediately.
+        // This runs before the Stripe re-query so the subscription is active right away.
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if (!empty($_REQUEST['subscriptionId'])) {
+            $subscriptionId = absint($_REQUEST['subscriptionId']);
+            if ($subscriptionId) {
+                (new Subscriptions())->updateData($subscriptionId, [
+                    'status'     => 'active',
+                    'updated_at' => current_time('mysql'),
+                ]);
+            }
+        }
+
+        // Fallback / full update: re-query Stripe to record charge details, card info, etc.
+        // Also activates subscription if subscription_id is on the transaction (covers webhook-less setups).
         (new PaymentHelper())->updatePaymentData($intentId);
+
         wp_send_json_success([
             'message' => __('Payment confirmation received', 'buy-me-coffee')
         ], 200);
@@ -162,6 +191,36 @@ class Stripe extends BaseMethods
             exit;
         }
 
+        $eventType = isset($data->type) ? sanitize_text_field($data->type) : '';
+        if (!$eventType) {
+            status_header(400);
+            exit;
+        }
+
+        // Handle subscription-specific webhook events
+        $subscriptionEvents = [
+            'invoice.payment_succeeded',
+            'customer.subscription.deleted',
+            'customer.subscription.updated',
+        ];
+
+        if (in_array($eventType, $subscriptionEvents, true)) {
+            $keys    = StripeSettings::getKeys();
+            $handler = new StripeSubscriptions();
+
+            if ($eventType === 'invoice.payment_succeeded') {
+                $handler->handleRenewalWebhook($data, $keys['secret']);
+            } elseif ($eventType === 'customer.subscription.deleted') {
+                $handler->handleSubscriptionCancelled($data);
+            } elseif ($eventType === 'customer.subscription.updated') {
+                $handler->handleSubscriptionUpdated($data);
+            }
+
+            status_header(200);
+            exit;
+        }
+
+        // Existing one-time payment event handling
         $eventId = isset($data->id) ? sanitize_text_field($data->id) : '';
         if (!$eventId) {
             status_header(400);

--- a/includes/Builder/Methods/Stripe/StripeSubscriptions.php
+++ b/includes/Builder/Methods/Stripe/StripeSubscriptions.php
@@ -1,0 +1,335 @@
+<?php
+
+namespace BuyMeCoffee\Builder\Methods\Stripe;
+
+use BuyMeCoffee\Models\Subscriptions;
+use BuyMeCoffee\Models\Supporters;
+use BuyMeCoffee\Models\Transactions;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+class StripeSubscriptions
+{
+    /**
+     * Create a Stripe subscription and return the inline payment intent for the first invoice.
+     *
+     * @param object $transaction  Transaction row
+     * @param array  $paymentArgs  Shared payment arguments (amount, currency, keys, etc.)
+     * @param string $apiKey       Stripe secret key
+     * @param string $interval     'month' or 'year'
+     */
+    public function createSubscription($transaction, $paymentArgs, $apiKey, $interval)
+    {
+        try {
+            // Always create a Stripe customer — subscriptions require it
+            $customerData = [];
+            if (!empty($paymentArgs['supporters_name'])) {
+                $customerData['name'] = sanitize_text_field($paymentArgs['supporters_name']);
+            }
+            if (!empty($paymentArgs['supporters_email'])) {
+                $customerData['email'] = sanitize_email($paymentArgs['supporters_email']);
+            }
+
+            $customer = (new API())->makeRequest('customers', $customerData, $apiKey, 'POST');
+
+            if (is_wp_error($customer) || empty($customer['id'])) {
+                wp_send_json_error([
+                    'status'  => 'failed',
+                    'message' => __('Could not create Stripe customer. Please try again.', 'buy-me-coffee'),
+                ], 423);
+                return;
+            }
+
+            $customerId = $customer['id'];
+
+            // Create (or reuse cached) Stripe product for recurring donations
+            $mode      = (strpos($apiKey, 'sk_live_') === 0) ? 'live' : 'test';
+            $productId = $this->getOrCreateProduct($apiKey, $mode);
+
+            // Build subscription payload
+            $priceData = [
+                'currency'    => strtolower($paymentArgs['currency']),
+                'unit_amount' => (int) $paymentArgs['amount'],
+                'recurring'   => ['interval' => $interval],
+            ];
+
+            if ($productId) {
+                $priceData['product'] = $productId;
+            } else {
+                // Fallback: inline product_data (newer API versions only)
+                $priceData['product_data'] = ['name' => __('Recurring Donation', 'buy-me-coffee')];
+            }
+
+            $subscriptionData = [
+                'customer' => $customerId,
+                'items'    => [['price_data' => $priceData]],
+                'payment_behavior' => 'default_incomplete',
+                'expand'           => ['latest_invoice.payment_intent'],
+                'metadata'         => [
+                    'ref_id'    => $paymentArgs['client_reference_id'],
+                    'supporter' => admin_url('admin.php?page=buy-me-coffee.php#/supporter/' . $paymentArgs['supporter_id']),
+                ],
+            ];
+
+            $stripeSubscription = (new API())->makeRequest('subscriptions', $subscriptionData, $apiKey, 'POST');
+
+            if (is_wp_error($stripeSubscription)) {
+                wp_send_json_error([
+                    'status'  => 'failed',
+                    'message' => $stripeSubscription->get_error_message(),
+                ], 423);
+            }
+
+            // Extract the payment intent from the first invoice
+            $paymentIntent = isset($stripeSubscription['latest_invoice']['payment_intent'])
+                ? $stripeSubscription['latest_invoice']['payment_intent']
+                : null;
+
+            if (!$paymentIntent) {
+                wp_send_json_error([
+                    'status'  => 'failed',
+                    'message' => __('Could not retrieve payment intent from subscription.', 'buy-me-coffee'),
+                ], 423);
+            }
+
+            // Stamp ref_id onto the payment intent so updatePaymentData() can find the order.
+            // Stripe puts subscription metadata on the subscription object, not the payment intent,
+            // so we explicitly update the PI here.
+            (new API())->makeRequest(
+                'payment_intents/' . $paymentIntent['id'],
+                ['metadata' => ['ref_id' => $paymentArgs['client_reference_id']]],
+                $apiKey,
+                'POST'
+            );
+
+            // Determine payment mode from Stripe object
+            $paymentMode = isset($stripeSubscription['livemode']) && $stripeSubscription['livemode'] ? 'live' : 'test';
+
+            // Insert local subscription record
+            $subscriptionModel = new Subscriptions();
+            $localSubscriptionId = $subscriptionModel->getQuery()->insert([
+                'supporter_id'          => (int) $paymentArgs['supporter_id'],
+                'stripe_subscription_id' => sanitize_text_field($stripeSubscription['id']),
+                'stripe_customer_id'    => $customerId ? sanitize_text_field($customerId) : '',
+                'interval_type'         => sanitize_text_field($interval),
+                'amount'                => (int) $paymentArgs['amount'],
+                'currency'              => sanitize_text_field(strtolower($paymentArgs['currency'])),
+                'status'                => 'incomplete',
+                'payment_mode'          => $paymentMode,
+                'created_at'            => current_time('mysql'),
+                'updated_at'            => current_time('mysql'),
+            ]);
+
+            // Link transaction to subscription
+            (new Transactions())->updateData($transaction->id, [
+                'transaction_type' => 'recurring',
+                'subscription_id'  => (int) $localSubscriptionId,
+                'updated_at'       => current_time('mysql'),
+            ]);
+
+            $transaction->payment_args   = $paymentArgs;
+            $transaction->subscription_id = (int) $localSubscriptionId;
+
+            wp_send_json_success([
+                'nextAction'      => 'stripe',
+                'actionName'      => 'custom',
+                'buttonState'     => 'hide',
+                'intent'          => $paymentIntent,
+                'order_items'     => $transaction,
+                'is_subscription' => true,
+                'subscription_id' => (int) $localSubscriptionId,
+                'message_to_show' => __('Setting up your recurring donation, please complete the payment below.', 'buy-me-coffee'),
+            ], 200);
+
+        } catch (\Exception $e) {
+            wp_send_json_error([
+                'status'  => 'failed',
+                'message' => $e->getMessage(),
+            ], 423);
+        }
+    }
+
+    /**
+     * Get or create a Stripe product for recurring donations.
+     * Caches the product ID in wp_options per mode (test/live) to avoid creating duplicates.
+     *
+     * @param string $apiKey  Stripe secret key
+     * @param string $mode    'test' or 'live'
+     * @return string|null    Stripe product ID, or null on failure
+     */
+    private function getOrCreateProduct($apiKey, $mode)
+    {
+        $optionKey = 'buymecoffee_stripe_recurring_product_' . $mode;
+        $cachedId  = get_option($optionKey, '');
+
+        if ($cachedId) {
+            return $cachedId;
+        }
+
+        $product = (new API())->makeRequest('products', [
+            'name'     => __('Recurring Donation', 'buy-me-coffee'),
+            'metadata' => ['source' => 'buy-me-coffee'],
+        ], $apiKey, 'POST');
+
+        if (is_wp_error($product) || empty($product['id'])) {
+            return null;
+        }
+
+        update_option($optionKey, $product['id'], false);
+
+        return $product['id'];
+    }
+
+    /**
+     * Handle invoice.payment_succeeded webhook.
+     * - If billing_reason = subscription_create: activate the subscription.
+     * - Otherwise: create a new renewal transaction.
+     *
+     * @param object $event    Validated webhook payload from IPNData()
+     * @param string $apiKey   Stripe secret key
+     */
+    public function handleRenewalWebhook($event, $apiKey)
+    {
+        $object        = isset($event->data->object) ? $event->data->object : null;
+        $stripeSubId   = isset($object->subscription) ? sanitize_text_field($object->subscription) : null;
+        $billingReason = isset($object->billing_reason) ? sanitize_text_field($object->billing_reason) : '';
+
+        if (!$stripeSubId) {
+            return;
+        }
+
+        $subscriptionModel = new Subscriptions();
+        $subscription      = $subscriptionModel->findByStripeId($stripeSubId);
+
+        if (!$subscription) {
+            return;
+        }
+
+        $periodEnd = isset($object->period_end) ? date('Y-m-d H:i:s', (int) $object->period_end) : null;
+
+        if ($billingReason === 'subscription_create') {
+            // First payment: activate the local subscription record
+            $subscriptionModel->updateData($subscription->id, [
+                'status'             => 'active',
+                'current_period_end' => $periodEnd,
+                'updated_at'         => current_time('mysql'),
+            ]);
+            return;
+        }
+
+        // Renewal: create a new transaction record
+        $amountPaid      = isset($object->amount_paid) ? (int) $object->amount_paid : 0;
+        $currency        = isset($object->currency) ? sanitize_text_field($object->currency) : 'usd';
+        $paymentIntentId = isset($object->payment_intent) ? sanitize_text_field($object->payment_intent) : '';
+
+        $chargeId = '';
+        if ($paymentIntentId && $apiKey) {
+            $pi = (new API())->makeRequest('payment_intents/' . $paymentIntentId, [], $apiKey, 'GET');
+            if (!is_wp_error($pi) && isset($pi['latest_charge'])) {
+                $chargeId = sanitize_text_field($pi['latest_charge']);
+            }
+        }
+
+        $supportersModel = new Supporters();
+        $supporter       = $supportersModel->find((int) $subscription->supporter_id);
+        if (!$supporter) {
+            return;
+        }
+
+        buyMeCoffeeQuery()->table('buymecoffee_transactions')->insert([
+            'entry_id'         => (int) $subscription->supporter_id,
+            'entry_hash'       => sanitize_text_field($supporter->entry_hash),
+            'subscription_id'  => (int) $subscription->id,
+            'transaction_type' => 'recurring',
+            'payment_method'   => 'stripe',
+            'charge_id'        => $chargeId,
+            'payment_total'    => $amountPaid,
+            'status'           => 'paid',
+            'currency'         => strtoupper($currency),
+            'payment_mode'     => sanitize_text_field($subscription->payment_mode),
+            'created_at'       => current_time('mysql'),
+            'updated_at'       => current_time('mysql'),
+        ]);
+
+        $subscriptionModel->updateData($subscription->id, [
+            'status'             => 'active',
+            'current_period_end' => $periodEnd,
+            'updated_at'         => current_time('mysql'),
+        ]);
+    }
+
+    /**
+     * Handle customer.subscription.deleted webhook.
+     *
+     * @param object $event  Validated webhook payload
+     */
+    public function handleSubscriptionCancelled($event)
+    {
+        $object      = isset($event->data->object) ? $event->data->object : null;
+        $stripeSubId = isset($object->id) ? sanitize_text_field($object->id) : null;
+
+        if (!$stripeSubId) {
+            return;
+        }
+
+        $subscriptionModel = new Subscriptions();
+        $subscription      = $subscriptionModel->findByStripeId($stripeSubId);
+
+        if (!$subscription) {
+            return;
+        }
+
+        $subscriptionModel->updateData($subscription->id, [
+            'status'       => 'cancelled',
+            'cancelled_at' => current_time('mysql'),
+            'updated_at'   => current_time('mysql'),
+        ]);
+    }
+
+    /**
+     * Handle customer.subscription.updated webhook.
+     *
+     * @param object $event  Validated webhook payload
+     */
+    public function handleSubscriptionUpdated($event)
+    {
+        $object      = isset($event->data->object) ? $event->data->object : null;
+        $stripeSubId = isset($object->id) ? sanitize_text_field($object->id) : null;
+
+        if (!$stripeSubId) {
+            return;
+        }
+
+        $subscriptionModel = new Subscriptions();
+        $subscription      = $subscriptionModel->findByStripeId($stripeSubId);
+
+        if (!$subscription) {
+            return;
+        }
+
+        $stripeStatus = isset($object->status) ? sanitize_text_field($object->status) : '';
+        $periodEnd    = isset($object->current_period_end) ? date('Y-m-d H:i:s', (int) $object->current_period_end) : null;
+
+        $update = ['updated_at' => current_time('mysql')];
+
+        if ($stripeStatus) {
+            $statusMap = [
+                'active'            => 'active',
+                'past_due'          => 'past_due',
+                'unpaid'            => 'past_due',
+                'canceled'          => 'cancelled',
+                'incomplete'        => 'incomplete',
+                'incomplete_expired' => 'cancelled',
+                'trialing'          => 'active',
+                'paused'            => 'past_due',
+            ];
+            $update['status'] = isset($statusMap[$stripeStatus]) ? $statusMap[$stripeStatus] : $stripeStatus;
+        }
+
+        if ($periodEnd) {
+            $update['current_period_end'] = $periodEnd;
+        }
+
+        $subscriptionModel->updateData($subscription->id, $update);
+    }
+}

--- a/includes/Builder/Render.php
+++ b/includes/Builder/Render.php
@@ -124,6 +124,8 @@ class Render
         $enableName = Arr::get($template, 'enableName') == 'yes';
         $enableEmail = Arr::get($template, 'enableEmail') == 'yes';
         $enableMsg = Arr::get($template, 'enableMessage') == 'yes';
+        $allowRecurring = Arr::get($template, 'allow_recurring', 'no') === 'yes';
+        $recurringInterval = Arr::get($template, 'recurring_interval', 'month');
         $defaultAmount = intval(Arr::get($template, 'defaultAmount', '5'));
         $customCoffeeDefault = intval(Arr::get($template, 'custom_coffee', '5'));
 
@@ -206,8 +208,12 @@ class Render
                 </div>
             <?php endif; ?>
 
-            <?php if ($enableEmail): ?>
-                <div data-element_type="email" class="buymecoffee_form_item">
+            <?php
+            // Show email field normally, or hidden-but-present when recurring is allowed
+            // (recurring requires an email for the Stripe customer)
+            $emailHiddenForRecurring = !$enableEmail && $allowRecurring;
+            if ($enableEmail || $allowRecurring) : ?>
+                <div data-element_type="email" class="buymecoffee_form_item<?php echo $emailHiddenForRecurring ? ' bmc_email_recurring_only' : ''; ?>"<?php echo $emailHiddenForRecurring ? ' style="display:none;"' : ''; ?>>
                     <div class="buymecoffee_input_content">
                         <input <?php
                         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -231,6 +237,18 @@ class Render
                     <?php echo esc_html(static::payMethod($template)); ?>
                 </div>
             </div>
+
+            <?php
+            $intervalLabel = $recurringInterval === 'year' ? __('yearly', 'buy-me-coffee') : __('monthly', 'buy-me-coffee');
+            if ($allowRecurring) : ?>
+            <div class="buymecoffee_recurring_section" style="display:none;" data-interval="<?php echo esc_attr($recurringInterval); ?>">
+                <label class="buymecoffee_recurring_label">
+                    <input type="checkbox" class="buymecoffee_is_recurring" name="buymecoffee_is_recurring" value="yes">
+                    <?php esc_html_e('Make it recurring', 'buy-me-coffee'); ?>
+                    <span class="buymecoffee_recurring_hint">(<?php echo esc_html(sprintf(/* translators: %s: billing interval, e.g. "monthly" */ __('billed %s', 'buy-me-coffee'), $intervalLabel)); ?>)</span>
+                </label>
+            </div>
+            <?php endif; ?>
 
             <div data-element_type="submit" class="buymecoffee_form_item buymecoffee_form_submit_wrapper">
                 <div class="buymecoffee_input_content">

--- a/includes/Classes/Activator.php
+++ b/includes/Classes/Activator.php
@@ -32,16 +32,20 @@ class Activator
         }
     }
 
+    public function maybeRunMigrations()
+    {
+        $installedVersion = get_option('buymecoffee_db_version', '1.0');
+        if (version_compare($installedVersion, BUYMECOFFEE_DB_VERSION, '<')) {
+            $this->migrate();
+            update_option('buymecoffee_db_version', BUYMECOFFEE_DB_VERSION);
+        }
+    }
+
     private function migrate()
     {
-        /*
-        * database creation commented out,
-        * If you need any database just active this function bellow
-        * and write your own query at function
-        */
-
         $this->createSupportersTable();
         $this->createTransactionTable();
+        $this->createSubscriptionsTable();
     }
 
     public function createSupportersTable()
@@ -95,6 +99,30 @@ class Activator
 				payment_note longtext,
 				created_at timestamp NULL,
 				updated_at timestamp NULL
+        ) $charset_collate;";
+
+        $this->runSQL($sql, $table_name);
+    }
+
+    public function createSubscriptionsTable()
+    {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $table_name = $wpdb->prefix . 'buymecoffee_subscriptions';
+        $sql = "CREATE TABLE $table_name (
+                id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                supporter_id int(11) NOT NULL,
+                stripe_subscription_id varchar(255),
+                stripe_customer_id varchar(255),
+                interval_type varchar(50) DEFAULT 'month',
+                amount int(11) DEFAULT 0,
+                currency varchar(10),
+                status varchar(50) DEFAULT 'incomplete',
+                payment_mode varchar(20) DEFAULT 'test',
+                current_period_end timestamp NULL,
+                cancelled_at timestamp NULL,
+                created_at timestamp NULL,
+                updated_at timestamp NULL
         ) $charset_collate;";
 
         $this->runSQL($sql, $table_name);

--- a/includes/Classes/AdminAjaxHandler.php
+++ b/includes/Classes/AdminAjaxHandler.php
@@ -13,7 +13,10 @@ use BuyMeCoffee\Helpers\Currencies;
 
 use BuyMeCoffee\Models\Buttons;
 use BuyMeCoffee\Models\Transactions;
+use BuyMeCoffee\Models\Subscriptions;
 use BuyMeCoffee\Classes\EmailNotifications;
+use BuyMeCoffee\Builder\Methods\Stripe\StripeSettings;
+use BuyMeCoffee\Builder\Methods\Stripe\API as StripeAPI;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
@@ -69,6 +72,10 @@ class AdminAjaxHandler
             'save_email_notification'  => 'saveEmailNotification',
             'send_test_email'          => 'sendTestEmail',
 
+            'get_subscriptions'      => 'getSubscriptions',
+            'get_subscription'       => 'getSubscription',
+            'cancel_subscription'    => 'cancelSubscription',
+            'get_subscription_stats' => 'getSubscriptionStats',
         );
 
         if (isset($validRoutes[$route])) {
@@ -317,5 +324,80 @@ class AdminAjaxHandler
         EmailNotifications::send($to, $subject, $body);
 
         wp_send_json_success(['message' => __('Test email sent to ', 'buy-me-coffee') . $to], 200);
+    }
+
+    public function getSubscriptions($request)
+    {
+        (new Subscriptions())->index($request);
+    }
+
+    public function getSubscription($request)
+    {
+        $id           = intval(Arr::get($request, 'id'));
+        $subscription = (new Subscriptions())->find($id);
+
+        if (!$subscription) {
+            wp_send_json_error(['message' => __('Subscription not found', 'buy-me-coffee')], 404);
+        }
+
+        $supporter = (new Supporters())->find((int) $subscription->supporter_id);
+        if ($supporter) {
+            $subscription->supporters_name  = $supporter->supporters_name;
+            $subscription->supporters_email = $supporter->supporters_email;
+            $subscription->supporters_image = get_avatar_url($supporter->supporters_email);
+            $subscription->entry_hash       = $supporter->entry_hash;
+        }
+
+        // Fetch related transactions
+        $transactions = buyMeCoffeeQuery()
+            ->table('buymecoffee_transactions')
+            ->where('subscription_id', $id)
+            ->orderBy('created_at', 'DESC')
+            ->get();
+
+        $subscription->transactions = $transactions;
+
+        wp_send_json_success($subscription, 200);
+    }
+
+    public function cancelSubscription($request)
+    {
+        $id           = intval(Arr::get($request, 'id'));
+        $subscription = (new Subscriptions())->find($id);
+
+        if (!$subscription) {
+            wp_send_json_error(['message' => __('Subscription not found', 'buy-me-coffee')], 404);
+        }
+
+        if ($subscription->status === 'cancelled') {
+            wp_send_json_error(['message' => __('Subscription is already cancelled', 'buy-me-coffee')], 400);
+        }
+
+        // Cancel on Stripe
+        if (!empty($subscription->stripe_subscription_id)) {
+            $keys   = StripeSettings::getKeys();
+            $apiKey = $keys['secret'];
+            (new StripeAPI())->makeRequest(
+                'subscriptions/' . sanitize_text_field($subscription->stripe_subscription_id),
+                [],
+                $apiKey,
+                'DELETE'
+            );
+        }
+
+        // Update local record
+        (new Subscriptions())->updateData($id, [
+            'status'       => 'cancelled',
+            'cancelled_at' => current_time('mysql'),
+            'updated_at'   => current_time('mysql'),
+        ]);
+
+        wp_send_json_success(['message' => __('Subscription cancelled successfully', 'buy-me-coffee')], 200);
+    }
+
+    public function getSubscriptionStats()
+    {
+        $stats = (new Subscriptions())->getStats();
+        wp_send_json_success($stats, 200);
     }
 }

--- a/includes/Classes/EmailNotifications.php
+++ b/includes/Classes/EmailNotifications.php
@@ -22,14 +22,14 @@ class EmailNotifications
                 'label'   => 'Donor Confirmation',
                 'enabled' => true,
                 'subject' => 'Thank you for your support, {{donor_name}}!',
-                'body'    => "Hi {{donor_name}},\n\nThank you so much for your generous support of {{amount}}! Your contribution means the world to us.\n\nWe received your donation via {{payment_method}}.\n\nWarm regards,\n{{site_name}}",
+                'body'    => "Hi {{donor_name}},\n\nThank you so much for your generous support of {{amount}}! Your contribution means the world to us.\n\nPayment type: {{payment_type}}\n{{recurring_note}}We received your donation via {{payment_method}}.\n\nWarm regards,\n{{site_name}}",
             ],
             'admin' => [
                 'id'      => 'admin',
                 'label'   => 'Admin Notification',
                 'enabled' => true,
                 'subject' => 'New donation received: {{amount}} from {{donor_name}}',
-                'body'    => "Hello,\n\nA new donation has been received.\n\nDonor: {{donor_name}}\nEmail: {{donor_email}}\nAmount: {{amount}}\nMethod: {{payment_method}}\n\nManage supporters: {{site_url}}\n\n{{site_name}}",
+                'body'    => "Hello,\n\nA new donation has been received.\n\nDonor: {{donor_name}}\nEmail: {{donor_email}}\nAmount: {{amount}}\nType: {{payment_type}}\n{{recurring_note}}Method: {{payment_method}}\n\nManage supporters: {{site_url}}\n\n{{site_name}}",
             ],
         ];
     }
@@ -95,14 +95,38 @@ class EmailNotifications
      */
     public static function buildVars($transaction, $supporter)
     {
-        $currency = strtoupper($transaction->currency ?? 'USD');
-        $amount   = number_format($transaction->payment_total / 100, 2) . ' ' . $currency;
+        $currency    = strtoupper($transaction->currency ?? 'USD');
+        $amount      = number_format($transaction->payment_total / 100, 2) . ' ' . $currency;
+        $isRecurring = ($transaction->transaction_type ?? '') === 'recurring';
+
+        $paymentType    = $isRecurring ? __('Recurring', 'buy-me-coffee') : __('One-time', 'buy-me-coffee');
+        $recurringNote  = '';
+
+        if ($isRecurring && !empty($transaction->subscription_id)) {
+            $subscription = buyMeCoffeeQuery()
+                ->table('buymecoffee_subscriptions')
+                ->where('id', (int) $transaction->subscription_id)
+                ->first();
+
+            if ($subscription) {
+                $interval      = ($subscription->interval_type ?? 'month') === 'year'
+                    ? __('yearly', 'buy-me-coffee')
+                    : __('monthly', 'buy-me-coffee');
+                $recurringNote = sprintf(
+                    /* translators: %s: billing interval, e.g. "monthly" */
+                    __("You will be billed %s. You can cancel anytime.\n", 'buy-me-coffee'),
+                    $interval
+                );
+            }
+        }
 
         return [
             'donor_name'     => $supporter->supporters_name ?: 'Anonymous',
             'donor_email'    => $supporter->supporters_email ?: '',
             'amount'         => $amount,
             'payment_method' => ucfirst($transaction->payment_method ?? ''),
+            'payment_type'   => $paymentType,
+            'recurring_note' => $recurringNote,
             'site_name'      => get_bloginfo('name'),
             'site_url'       => site_url(),
             'admin_email'    => get_option('admin_email'),

--- a/includes/Controllers/SubmissionHandler.php
+++ b/includes/Controllers/SubmissionHandler.php
@@ -54,8 +54,19 @@ class SubmissionHandler
             $currency = PaymentHelper::getCurrency();
         }
 
-        $form_data['payment_method'] = $paymentMethod;
-        $form_data['payment_total'] = $paymentTotal;
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Public form submission
+        $isRecurring      = isset($_REQUEST['is_recurring']) ? sanitize_text_field(wp_unslash($_REQUEST['is_recurring'])) : 'no';
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Public form submission
+        $recurringInterval = isset($_REQUEST['recurring_interval']) ? sanitize_text_field(wp_unslash($_REQUEST['recurring_interval'])) : 'month';
+        $allowedIntervals  = ['month', 'year'];
+        if (!in_array($recurringInterval, $allowedIntervals, true)) {
+            $recurringInterval = 'month';
+        }
+
+        $form_data['payment_method']      = $paymentMethod;
+        $form_data['payment_total']       = $paymentTotal;
+        $form_data['is_recurring']        = $isRecurring;
+        $form_data['recurring_interval']  = $recurringInterval;
 
         $supporterName = ArrayHelper::get($form_data, 'wpm-supporter-name', 'Anonymous');
         $supporterEmail = ArrayHelper::get($form_data, 'wpm-supporter-email');
@@ -91,15 +102,16 @@ class SubmissionHandler
         do_action('buymecoffee_after_supporters_data_insert', $entries);
 
         $transaction = array(
-            'entry_hash' => $hash,
-            'entry_id' => $entryId,
-            'charge_id' => '',
-            'payment_method' => sanitize_text_field($paymentMethod),
-            'payment_total' => $paymentTotal,
-            'currency' => $currency,
-            'status' => 'pending',
-            'created_at' => current_time('mysql'),
-            'updated_at' => current_time('mysql'),
+            'entry_hash'       => $hash,
+            'entry_id'         => $entryId,
+            'charge_id'        => '',
+            'payment_method'   => sanitize_text_field($paymentMethod),
+            'payment_total'    => $paymentTotal,
+            'currency'         => $currency,
+            'status'           => 'pending',
+            'transaction_type' => $isRecurring === 'yes' ? 'recurring' : 'one_time',
+            'created_at'       => current_time('mysql'),
+            'updated_at'       => current_time('mysql'),
         );
 
          $transactionTable = (new Transactions())->getQuery();

--- a/includes/Helpers/PaymentHelper.php
+++ b/includes/Helpers/PaymentHelper.php
@@ -8,6 +8,7 @@ use BuyMeCoffee\Controllers\SubmissionHandler;
 use BuyMeCoffee\Models\Buttons;
 use BuyMeCoffee\Models\Supporters;
 use BuyMeCoffee\Helpers\ArrayHelper as Arr;
+use BuyMeCoffee\Models\Subscriptions;
 use BuyMeCoffee\Models\Transactions;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
@@ -46,7 +47,10 @@ class PaymentHelper
             return;
         }
 
-        if (intval($order->payment_total) !== $amount) {
+        // For subscriptions the PI amount may not yet be reflected in amount_received
+        // at the moment the confirmation fires, so allow a zero amount_received to pass
+        // (the status check below still gates on 'succeeded').
+        if ($amount > 0 && intval($order->payment_total) !== $amount) {
             return;
         }
 
@@ -68,6 +72,17 @@ class PaymentHelper
             'updated_at' => current_time('mysql')
         ]);
         (new Transactions())->updateData($order->transaction->id, $updateData);
+
+        // If this transaction belongs to a subscription, activate it now.
+        // Webhooks also do this, but the frontend confirmation fires first and
+        // without this the subscription stays 'incomplete' until the webhook arrives.
+        if ($status === 'paid' && !empty($order->transaction->subscription_id)) {
+            (new Subscriptions())->updateData((int) $order->transaction->subscription_id, [
+                'status'     => 'active',
+                'updated_at' => current_time('mysql'),
+            ]);
+        }
+
         do_action('buymecoffee_payment_status_updated', $order->transaction->id, $status);
     }
 

--- a/includes/Models/Buttons.php
+++ b/includes/Models/Buttons.php
@@ -21,6 +21,8 @@ class Buttons
             "custom_coffee" => 5,
             "openMode" => 'page',
             "currency" => 'USD',
+            "allow_recurring" => 'no',
+            "recurring_interval" => 'month',
             "advanced" => array(
                 "image" => '',
                 "banner_image" => '',

--- a/includes/Models/Subscriptions.php
+++ b/includes/Models/Subscriptions.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace BuyMeCoffee\Models;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+class Subscriptions extends Model
+{
+    protected $table = 'buymecoffee_subscriptions';
+
+    public function updateData($id, $data)
+    {
+        return $this->getQuery()->where('id', $id)->update($data);
+    }
+
+    public function findByStripeId($stripeSubscriptionId)
+    {
+        return $this->getQuery()
+            ->where('stripe_subscription_id', sanitize_text_field($stripeSubscriptionId))
+            ->first();
+    }
+
+    public function index($args = [])
+    {
+        global $wpdb;
+
+        $page           = isset($args['page']) ? max(0, intval($args['page'])) : 0;
+        $posts_per_page = isset($args['posts_per_page']) ? max(1, intval($args['posts_per_page'])) : 10;
+        $search         = isset($args['search']) ? sanitize_text_field($args['search']) : '';
+        $filter_status  = isset($args['filter_status']) ? sanitize_text_field($args['filter_status']) : 'all';
+
+        $sub_table  = $wpdb->prefix . 'buymecoffee_subscriptions';
+        $sup_table  = $wpdb->prefix . 'buymecoffee_supporters';
+
+        $where   = [];
+        $params  = [];
+
+        if ($filter_status && $filter_status !== 'all') {
+            $where[]  = 's.status = %s';
+            $params[] = $filter_status;
+        }
+
+        if ($search) {
+            $where[]  = '(sup.supporters_name LIKE %s OR sup.supporters_email LIKE %s)';
+            $like     = '%' . $wpdb->esc_like($search) . '%';
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $where_sql = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are safe (prefixed by wpdb)
+        $count_sql = "SELECT COUNT(*) FROM $sub_table s LEFT JOIN $sup_table sup ON s.supporter_id = sup.id $where_sql";
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $total = $params
+            ? (int) $wpdb->get_var($wpdb->prepare($count_sql, $params))
+            : (int) $wpdb->get_var($count_sql); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+        $offset = $page * $posts_per_page;
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are safe
+        $data_sql = "SELECT s.*, sup.supporters_name, sup.supporters_email
+                     FROM $sub_table s
+                     LEFT JOIN $sup_table sup ON s.supporter_id = sup.id
+                     $where_sql
+                     ORDER BY s.created_at DESC
+                     LIMIT %d OFFSET %d";
+
+        $query_params   = array_merge($params, [$posts_per_page, $offset]);
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $results = $wpdb->get_results($wpdb->prepare($data_sql, $query_params));
+
+        wp_send_json_success([
+            'subscriptions' => $results,
+            'total'         => $total,
+        ], 200);
+    }
+
+    public function getStats()
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'buymecoffee_subscriptions';
+
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $active_count = (int) $wpdb->get_var(
+            $wpdb->prepare("SELECT COUNT(*) FROM $table WHERE status = %s", 'active')
+        );
+
+        // MRR: sum of monthly-normalised amounts for active subscriptions
+        // yearly amounts are divided by 12
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT amount, interval_type FROM $table WHERE status = %s",
+                'active'
+            )
+        );
+
+        $mrr = 0;
+        foreach ($rows as $row) {
+            $amount = (int) $row->amount;
+            if ($row->interval_type === 'year') {
+                $mrr += (int) round($amount / 12);
+            } else {
+                $mrr += $amount;
+            }
+        }
+
+        return [
+            'active_count' => $active_count,
+            'mrr'          => $mrr,
+        ];
+    }
+}

--- a/includes/Models/Supporters.php
+++ b/includes/Models/Supporters.php
@@ -175,6 +175,13 @@ class Supporters extends Model
                 ->where('entry_hash', $hash)
                 ->first();
             $supporter->transaction = $transaction;
+
+            if ($transaction && ($transaction->transaction_type ?? '') === 'recurring' && !empty($transaction->subscription_id)) {
+                $supporter->subscription = buyMeCoffeeQuery()
+                    ->table('buymecoffee_subscriptions')
+                    ->where('id', (int) $transaction->subscription_id)
+                    ->first();
+            }
         }
         return $supporter;
     }

--- a/includes/views/templates/Confirmation.php
+++ b/includes/views/templates/Confirmation.php
@@ -7,6 +7,13 @@ use BuyMeCoffee\Helpers\PaymentHelper;
 if ($paymentData):
     $amount = floatval($paymentData->payment_total ? $paymentData->payment_total / 100 : 0);
     $currencySymbol = html_entity_decode(PaymentHelper::currencySymbol($paymentData->currency ?? 'USD'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $isRecurring = isset($paymentData->transaction) && ($paymentData->transaction->transaction_type ?? '') === 'recurring';
+    $recurringInterval = '';
+    if ($isRecurring && isset($paymentData->subscription)) {
+        $recurringInterval = ($paymentData->subscription->interval_type ?? 'month') === 'year'
+            ? __('Yearly', 'buy-me-coffee')
+            : __('Monthly', 'buy-me-coffee');
+    }
 ?>
 <div class="bmc-receipt">
     <!-- Success header -->
@@ -16,13 +23,26 @@ if ($paymentData):
                 <polyline points="20 6 9 17 4 12"></polyline>
             </svg>
         </div>
-        <h2 class="bmc-receipt__title"><?php esc_html_e('Payment Successful!', 'buy-me-coffee'); ?></h2>
-        <p class="bmc-receipt__subtitle"><?php esc_html_e('Thank you for your generous support', 'buy-me-coffee'); ?></p>
+        <h2 class="bmc-receipt__title">
+            <?php echo $isRecurring ? esc_html__('Subscription Active!', 'buy-me-coffee') : esc_html__('Payment Successful!', 'buy-me-coffee'); ?>
+        </h2>
+        <p class="bmc-receipt__subtitle">
+            <?php echo $isRecurring
+                ? esc_html__('Thank you for your recurring support', 'buy-me-coffee')
+                : esc_html__('Thank you for your generous support', 'buy-me-coffee'); ?>
+        </p>
+        <?php if ($isRecurring): ?>
+        <span class="bmc-receipt__recurring-badge">
+            ↻ <?php echo $recurringInterval ? esc_html($recurringInterval . ' ' . __('Recurring Donation', 'buy-me-coffee')) : esc_html__('Recurring Donation', 'buy-me-coffee'); ?>
+        </span>
+        <?php endif; ?>
     </div>
 
     <!-- Amount -->
     <div class="bmc-receipt__amount-box">
-        <span class="bmc-receipt__amount-label"><?php esc_html_e('Amount Paid', 'buy-me-coffee'); ?></span>
+        <span class="bmc-receipt__amount-label">
+            <?php echo $isRecurring ? esc_html__('Amount per Cycle', 'buy-me-coffee') : esc_html__('Amount Paid', 'buy-me-coffee'); ?>
+        </span>
         <span class="bmc-receipt__amount-value"><?php echo esc_html($currencySymbol . number_format($amount, 2)); ?></span>
         <span class="bmc-receipt__amount-coffees">
             <?php echo esc_html($paymentData->coffee_count ?? 1); ?>
@@ -60,6 +80,19 @@ if ($paymentData):
         <div class="bmc-receipt__row">
             <span class="bmc-receipt__label"><?php esc_html_e('Payment Method', 'buy-me-coffee'); ?></span>
             <span class="bmc-receipt__value" style="text-transform: capitalize"><?php echo esc_html($paymentData->payment_method ?? ''); ?></span>
+        </div>
+
+        <div class="bmc-receipt__row">
+            <span class="bmc-receipt__label"><?php esc_html_e('Donation Type', 'buy-me-coffee'); ?></span>
+            <span class="bmc-receipt__value">
+                <?php if ($isRecurring): ?>
+                    <span class="bmc-receipt__type-badge bmc-receipt__type-badge--recurring">
+                        ↻ <?php echo $recurringInterval ? esc_html($recurringInterval) : esc_html__('Recurring', 'buy-me-coffee'); ?>
+                    </span>
+                <?php else: ?>
+                    <?php esc_html_e('One-time', 'buy-me-coffee'); ?>
+                <?php endif; ?>
+            </span>
         </div>
 
         <div class="bmc-receipt__row">

--- a/src/js/BmcFormHandler.js
+++ b/src/js/BmcFormHandler.js
@@ -1,3 +1,5 @@
+import BmcCoffeeLoader from './utils/coffeeLoader.js';
+
 class BmcFormHandler {
     constructor(form, config) {
         this.form = form;
@@ -47,6 +49,12 @@ class BmcFormHandler {
             jQuery(e.target).parent().addClass('wpm_payment_active');
         });
 
+
+        // Show/require email when recurring is checked
+        this.form.find('.buymecoffee_is_recurring').on('change', (e) => {
+            this.toggleRecurringEmail(e.target.checked);
+        });
+
         this.form.on('submit', (e) => {
             e.preventDefault();
             this.handleFormSubmit(this.form);
@@ -54,10 +62,38 @@ class BmcFormHandler {
     }
 
 
+    toggleRecurringEmail(isChecked) {
+        const emailField = this.form.find('.bmc_email_recurring_only');
+        if (!emailField.length) return; // email already visible (enableEmail=yes)
+        if (isChecked) {
+            emailField.slideDown(150);
+        } else {
+            emailField.slideUp(150);
+            emailField.find('input').val('');
+        }
+    }
+
     handleFormSubmit(form) {
+        // Validate email is present when recurring is selected
+        if (form.find('.buymecoffee_is_recurring').is(':checked')) {
+            const emailVal = form.find('input.wpm-supporter-email').val()?.trim();
+            if (!emailVal) {
+                const emailField = form.find('[data-element_type="email"]');
+                emailField.addClass('bmc_field_error');
+                emailField.find('input').attr('placeholder', 'Email is required for recurring donations');
+                form.find('button.wpm_submit_button').removeAttr('disabled');
+                emailField.find('input').one('input', () => emailField.removeClass('bmc_field_error'));
+                return;
+            }
+        }
+
         form.find('button.wpm_submit_button').attr('disabled', true);
         form.addClass('wpm_submitting_form');
         form.parent().find('.wpm_form_notices').hide();
+
+        const card = form.closest('.bmc-form-card, .buymecoffee_form_preview_wrapper')[0] || form.parent()[0];
+        const loader = new BmcCoffeeLoader(card);
+        loader.show();
 
         jQuery.post(window.buymecoffee_general.ajax_url, {
             action: 'buymecoffee_submit',
@@ -66,9 +102,12 @@ class BmcFormHandler {
             coffee_count: form.data('coffee_count'),
             payment_method: form.data('wpm_selected_payment_method'),
             currency: form.data('wpm_currency'),
-            form_data: jQuery(form).serializeArray()
+            form_data: jQuery(form).serializeArray(),
+            is_recurring: form.find('.buymecoffee_is_recurring').is(':checked') ? 'yes' : 'no',
+            recurring_interval: form.find('.buymecoffee_recurring_section').data('interval') || 'month',
         })
             .then(response => {
+                loader.hide();
                 if (response.data?.redirectTo) {
                     window.location.href = response.data.redirectTo;
                 }
@@ -76,7 +115,10 @@ class BmcFormHandler {
                     this.fireCustomEvent(response.data.nextAction, response);
                     return;
                 }
-            }).catch (error => {
+            }).catch(error => {
+                loader.hide();
+                form.find('button.wpm_submit_button').removeAttr('disabled');
+                form.removeClass('wpm_submitting_form');
                 alert(error?.responseJSON?.data?.message);
             });
     }
@@ -105,6 +147,14 @@ class BmcFormHandler {
         let paymentMethod = this.form.find('.buymecoffee_pay_method input:checked');
         this.form.data('wpm_selected_payment_method', paymentMethod.val());
         paymentMethod.parent().addClass('wpm_payment_active');
+
+        // Show recurring option only for Stripe
+        const isStripe = paymentMethod.val() === 'stripe';
+        this.form.find('.buymecoffee_recurring_section').toggle(isStripe);
+        if (!isStripe) {
+            this.form.find('.buymecoffee_is_recurring').prop('checked', false);
+            this.toggleRecurringEmail(false);
+        }
     }
 
     toggleCustomQuantity(val) {

--- a/src/js/Components/Dashboard.vue
+++ b/src/js/Components/Dashboard.vue
@@ -53,6 +53,18 @@
         icon="Clock"
         color="sky"
       />
+      <MetricCard
+        label="Active Subscriptions"
+        :value="String(subscriptionStats.active_count || 0)"
+        icon="RefreshCw"
+        color="green"
+      />
+      <MetricCard
+        label="Monthly Recurring"
+        :value="mrrFormatted"
+        icon="TrendingUp"
+        color="emerald"
+      />
     </div>
 
     <!-- Revenue Chart -->
@@ -206,6 +218,10 @@ export default {
       selectedCurrency: '',
       currencyOptions: [],
       chartDataMap: {},
+      subscriptionStats: {
+        active_count: 0,
+        mrr: 0,
+      },
       reportData: {
         total_supporters: 0,
         total_coffee: 0,
@@ -299,6 +315,10 @@ export default {
       return this.reportData.currency_total_pending
         .map(c => this.stripHtml(c.formatted_total))
         .join(' / ');
+    },
+    mrrFormatted() {
+      const mrr = this.subscriptionStats.mrr || 0;
+      return '$' + (mrr / 100).toFixed(2);
     }
   },
   methods: {
@@ -380,6 +400,17 @@ export default {
           this.$handleError(e);
         });
     },
+    getSubscriptionStats() {
+      this.$get({
+        action: 'buymecoffee_admin_ajax',
+        route: 'get_subscription_stats',
+        buymecoffee_nonce: window.BuyMeCoffeeAdmin.buymecoffee_nonce
+      }).then((response) => {
+        if (response?.data) {
+          this.subscriptionStats = response.data;
+        }
+      });
+    },
     onCurrencyChange(currency) {
       this.renderChart = false;
       this.top_paid_currency = currency;
@@ -401,6 +432,7 @@ export default {
   mounted() {
     this.getSupporters();
     this.getWeeklyRevenue();
+    this.getSubscriptionStats();
     if (window.localStorage) {
       this.guidedTour = !!window.localStorage.getItem('buymecoffee_guided_tour');
     }
@@ -416,9 +448,15 @@ export default {
 /* Metric cards grid */
 .bmc-metrics-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 16px;
   margin-bottom: 24px;
+}
+
+@media (min-width: 1280px) {
+  .bmc-metrics-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
 }
 
 @media (max-width: 1024px) {

--- a/src/js/Components/Settings.vue
+++ b/src/js/Components/Settings.vue
@@ -96,6 +96,28 @@
                   </el-select>
                 </div>
               </div>
+
+              <!-- Allow recurring -->
+              <div class="bmc-toggle-row" :class="{ 'bmc-toggle-row--last': template.allow_recurring !== 'yes' }" style="margin-top: 4px">
+                <div class="bmc-toggle-row__text">
+                  <p class="bmc-toggle-row__label">Allow recurring</p>
+                  <p class="bmc-toggle-row__desc">Show a "Make it recurring" option on the checkout form (Stripe only)</p>
+                </div>
+                <el-switch v-model="template.allow_recurring" active-value="yes" inactive-value="no" />
+              </div>
+
+              <!-- Recurring interval -->
+              <div v-if="template.allow_recurring === 'yes'" class="bmc-toggle-row bmc-toggle-row--last">
+                <div class="bmc-toggle-row__text">
+                  <p class="bmc-toggle-row__label">Recurring interval</p>
+                  <p class="bmc-toggle-row__desc">How often supporters will be charged</p>
+                </div>
+                <el-select v-model="template.recurring_interval" style="width: 130px">
+                  <el-option label="Monthly" value="month" />
+                  <el-option label="Yearly" value="year" />
+                </el-select>
+              </div>
+
             </div>
           </section>
 
@@ -431,6 +453,8 @@ export default {
         enableEmail: 'no',
         defaultAmount: 5,
         currency: 'USD',
+        allow_recurring: 'no',
+        recurring_interval: 'month',
         advanced: {
           image: '',
           bgColor: '#ff813f',

--- a/src/js/Components/Stripe.vue
+++ b/src/js/Components/Stripe.vue
@@ -94,6 +94,15 @@
                         </a>
                     </div>
                     <CodeBlock :code="webhook_url" />
+                    <div class="mt-3 p-3 rounded-lg bg-neutral-50 border border-neutral-200">
+                        <p class="text-xs font-medium text-[var(--text-secondary)] mb-1">Required webhook events:</p>
+                        <ul class="text-xs text-[var(--text-tertiary)] space-y-0.5 list-none m-0 p-0">
+                            <li>• <code class="text-xs">charge.succeeded</code></li>
+                            <li>• <code class="text-xs">invoice.payment_succeeded</code> — recurring renewal payments</li>
+                            <li>• <code class="text-xs">customer.subscription.deleted</code> — subscription cancellations</li>
+                            <li>• <code class="text-xs">customer.subscription.updated</code> — status changes</li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/js/Components/Subscriptions/SubscriptionDetail.vue
+++ b/src/js/Components/Subscriptions/SubscriptionDetail.vue
@@ -1,0 +1,347 @@
+<template>
+  <div class="relative min-h-[200px]">
+    <CoffeeLoader :loading="loading" />
+
+    <!-- Back Button -->
+    <button class="bmc-back-btn" @click="$router.push({ name: 'Subscriptions' })">
+      <ArrowLeft :size="16" />
+      Back to Subscriptions
+    </button>
+
+    <template v-if="!loading && subscription.id">
+      <!-- Profile + Subscription Overview Card -->
+      <div class="bg-white rounded-xl border border-neutral-200 shadow-xs p-6 mb-6">
+        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <!-- Left: Avatar + Info -->
+          <div class="flex items-start gap-4">
+            <img
+              v-if="subscription.supporters_image"
+              :src="subscription.supporters_image"
+              :alt="subscription.supporters_name"
+              class="w-16 h-16 rounded-full border-2 border-neutral-200 object-cover flex-shrink-0"
+            />
+            <div
+              v-else
+              class="w-16 h-16 rounded-full border-2 border-neutral-200 flex items-center justify-center flex-shrink-0"
+              style="background: var(--color-primary-50); color: var(--color-primary-600)"
+            >
+              <span class="text-xl font-bold uppercase">{{ getInitials(subscription.supporters_name) }}</span>
+            </div>
+
+            <div>
+              <h2 class="text-xl font-bold m-0" style="color: var(--text-primary)">
+                {{ subscription.supporters_name || 'Anonymous' }}
+              </h2>
+              <p v-if="subscription.supporters_email" class="text-sm mt-0.5 mb-0" style="color: var(--text-secondary)">
+                {{ subscription.supporters_email }}
+              </p>
+              <div class="flex flex-wrap items-center gap-2 mt-2">
+                <span class="bmc-status-badge" :class="'bmc-status-badge--' + subscription.status">
+                  {{ statusLabel(subscription.status) }}
+                </span>
+                <span class="text-xs px-2 py-0.5 rounded-full border border-neutral-200" style="color: var(--text-secondary)">
+                  {{ subscription.interval_type === 'year' ? 'Yearly' : 'Monthly' }}
+                </span>
+                <span class="text-xs" style="color: var(--text-tertiary)">
+                  Since {{ formatDate(subscription.created_at) }}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right: Actions -->
+          <div class="flex flex-wrap items-center gap-2">
+            <a
+              v-if="subscription.supporters_email"
+              :href="'mailto:' + subscription.supporters_email"
+              class="bmc-action-btn no-underline"
+            >
+              <Mail :size="14" />
+              Send Email
+            </a>
+            <a
+              v-if="subscription.stripe_subscription_id"
+              :href="stripeSubUrl()"
+              target="_blank"
+              rel="noopener"
+              class="bmc-action-btn no-underline"
+            >
+              <ExternalLink :size="14" />
+              View on Stripe
+            </a>
+
+            <!-- Three-dot more menu -->
+            <div v-if="subscription.status !== 'cancelled'" class="bmc-more-menu" ref="moreMenu">
+              <button class="bmc-action-btn bmc-action-btn--icon" @click.stop="moreOpen = !moreOpen">
+                <MoreVertical :size="16" />
+              </button>
+              <div v-if="moreOpen" class="bmc-more-dropdown">
+                <el-popconfirm
+                  title="Cancel this subscription? This cannot be undone."
+                  confirm-button-text="Yes, cancel"
+                  cancel-button-text="No"
+                  :width="260"
+                  @confirm="cancelSubscription"
+                >
+                  <template #reference>
+                    <button class="bmc-more-item bmc-more-item--danger" :disabled="cancelling">
+                      <XCircle :size="14" />
+                      {{ cancelling ? 'Cancelling...' : 'Cancel Subscription' }}
+                    </button>
+                  </template>
+                </el-popconfirm>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Subscription Details Grid -->
+        <div class="bmc-detail-grid mt-6 pt-6 border-t border-neutral-200">
+          <div class="bmc-detail-item">
+            <span class="bmc-detail-label">Amount</span>
+            <span class="bmc-detail-value">{{ formatAmount(subscription.amount, subscription.currency) }}</span>
+          </div>
+          <div class="bmc-detail-item">
+            <span class="bmc-detail-label">Interval</span>
+            <span class="bmc-detail-value">{{ subscription.interval_type === 'year' ? 'Yearly' : 'Monthly' }}</span>
+          </div>
+          <div class="bmc-detail-item">
+            <span class="bmc-detail-label">Status</span>
+            <span class="bmc-status-badge" :class="'bmc-status-badge--' + subscription.status">
+              {{ statusLabel(subscription.status) }}
+            </span>
+          </div>
+          <div class="bmc-detail-item">
+            <span class="bmc-detail-label">Next Renewal</span>
+            <span class="bmc-detail-value">{{ formatDate(subscription.current_period_end) }}</span>
+          </div>
+          <div class="bmc-detail-item">
+            <span class="bmc-detail-label">Payment Mode</span>
+            <span class="bmc-detail-value" style="text-transform: capitalize">{{ subscription.payment_mode || '--' }}</span>
+          </div>
+          <div class="bmc-detail-item" v-if="subscription.cancelled_at">
+            <span class="bmc-detail-label">Cancelled At</span>
+            <span class="bmc-detail-value">{{ formatDate(subscription.cancelled_at) }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Payment History -->
+      <div class="bg-white rounded-xl border border-neutral-200 shadow-xs p-6">
+        <h3 class="text-base font-semibold mb-4 m-0" style="color: var(--text-primary)">Payment History</h3>
+
+        <el-table
+          v-if="subscription.transactions && subscription.transactions.length"
+          :data="subscription.transactions"
+          style="width: 100%"
+          :show-header="true"
+        >
+          <el-table-column label="Date" width="180">
+            <template #default="{ row }">
+              <span class="bmc-date">{{ formatDate(row.created_at) }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Amount" width="160">
+            <template #default="{ row }">
+              <span class="bmc-amount">{{ formatAmount(row.payment_total, row.currency) }}</span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Status" width="130">
+            <template #default="{ row }">
+              <span class="bmc-status-badge" :class="'bmc-status-badge--' + row.status">
+                {{ row.status }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Transaction ID" min-width="220">
+            <template #default="{ row }">
+              <a
+                v-if="row.charge_id"
+                :href="stripeChargeUrl(row)"
+                target="_blank"
+                rel="noopener"
+                class="bmc-charge-link"
+              >
+                {{ row.charge_id }}
+                <ExternalLink :size="12" />
+              </a>
+              <span v-else style="color: var(--text-tertiary)">--</span>
+            </template>
+          </el-table-column>
+        </el-table>
+
+        <EmptyState
+          v-else
+          title="No payments yet"
+          description="Renewal payments will appear here as they are processed."
+          icon="CreditCard"
+        />
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import { ArrowLeft, Mail, XCircle, ExternalLink, MoreVertical } from 'lucide-vue-next';
+import CoffeeLoader from '../UI/CoffeeLoader.vue';
+import EmptyState from '../UI/EmptyState.vue';
+
+export default {
+  name: 'SubscriptionDetail',
+  components: { ArrowLeft, Mail, XCircle, ExternalLink, MoreVertical, CoffeeLoader, EmptyState },
+  data() {
+    return {
+      loading: true,
+      cancelling: false,
+      moreOpen: false,
+      subscription: {},
+    };
+  },
+  methods: {
+    getSubscription() {
+      this.loading = true;
+      this.$get({
+        action: 'buymecoffee_admin_ajax',
+        route: 'get_subscription',
+        data: { id: this.$route.params.id },
+        buymecoffee_nonce: window.BuyMeCoffeeAdmin.buymecoffee_nonce,
+      }).then((response) => {
+        this.subscription = response?.data || {};
+      }).fail((error) => {
+        this.$handleError(error);
+      }).always(() => {
+        this.loading = false;
+      });
+    },
+    cancelSubscription() {
+      this.moreOpen = false;
+      this.cancelling = true;
+      this.$post({
+        action: 'buymecoffee_admin_ajax',
+        route: 'cancel_subscription',
+        data: { id: this.subscription.id },
+        buymecoffee_nonce: window.BuyMeCoffeeAdmin.buymecoffee_nonce,
+      }).then(() => {
+        this.subscription.status = 'cancelled';
+        this.subscription.cancelled_at = new Date().toISOString();
+        this.$handleSuccess('Subscription cancelled');
+      }).fail((error) => {
+        this.$handleError(error);
+      }).always(() => {
+        this.cancelling = false;
+      });
+    },
+    formatAmount(cents, currency) {
+      if (!cents) return '--';
+      return (cents / 100).toFixed(2) + ' ' + (currency || 'USD').toUpperCase();
+    },
+    formatDate(dateStr) {
+      if (!dateStr || dateStr === '0000-00-00 00:00:00') return '--';
+      return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    },
+    statusLabel(status) {
+      const labels = { active: 'Active', cancelled: 'Cancelled', incomplete: 'Incomplete', past_due: 'Past Due' };
+      return labels[status] || status;
+    },
+    getInitials(name) {
+      if (!name) return '?';
+      return name.split(' ').map(w => w[0]).slice(0, 2).join('').toUpperCase();
+    },
+    stripeChargeUrl(row) {
+      const mode = row.payment_mode === 'live' ? '' : 'test/';
+      return 'https://dashboard.stripe.com/' + mode + 'charges/' + row.charge_id;
+    },
+    stripeSubUrl() {
+      const mode = this.subscription.payment_mode === 'live' ? '' : 'test/';
+      return 'https://dashboard.stripe.com/' + mode + 'subscriptions/' + this.subscription.stripe_subscription_id;
+    },
+    onClickOutside(e) {
+      if (this.$refs.moreMenu && !this.$refs.moreMenu.contains(e.target)) {
+        this.moreOpen = false;
+      }
+    },
+  },
+  mounted() {
+    this.getSubscription();
+    document.addEventListener('click', this.onClickOutside);
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.onClickOutside);
+  },
+};
+</script>
+
+<style scoped>
+.bmc-back-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; margin-bottom: 16px;
+  border: 1px solid var(--border-primary); border-radius: 8px;
+  background: var(--bg-primary); color: var(--text-secondary);
+  font-size: 13px; font-weight: 500; cursor: pointer; transition: all 0.15s ease;
+}
+.bmc-back-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+.bmc-status-badge {
+  display: inline-flex; align-items: center;
+  padding: 2px 10px; border-radius: 9999px;
+  font-size: 12px; font-weight: 500;
+  max-width: 120px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; justify-content: center;
+  background: var(--color-neutral-100); color: var(--text-secondary);
+}
+.bmc-status-badge--active    { background: #dcfce7; color: #166534; }
+.bmc-status-badge--cancelled { background: #fee2e2; color: #991b1b; }
+.bmc-status-badge--incomplete{ background: #fef9c3; color: #854d0e; }
+.bmc-status-badge--past_due  { background: #ffedd5; color: #9a3412; }
+.bmc-status-badge--paid      { background: #dcfce7; color: #166534; }
+.bmc-status-badge--pending   { background: #fef9c3; color: #854d0e; }
+
+.bmc-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+@media (max-width: 768px) {
+  .bmc-detail-grid { grid-template-columns: repeat(2, 1fr); }
+}
+.bmc-detail-item { display: flex; flex-direction: column; gap: 4px; }
+.bmc-detail-label { font-size: 12px; font-weight: 500; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; }
+.bmc-detail-value { font-size: 14px; font-weight: 500; color: var(--text-primary); }
+
+.bmc-amount { font-size: 14px; font-weight: 600; color: var(--text-primary); }
+.bmc-date { font-size: 13px; color: var(--text-secondary); }
+
+.bmc-charge-link {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 12px; color: var(--color-primary-600);
+  text-decoration: none; font-family: monospace;
+}
+.bmc-charge-link:hover { text-decoration: underline; }
+
+.bmc-action-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; font-size: 13px; font-weight: 500;
+  border: 1px solid var(--border-primary); border-radius: 8px;
+  background: var(--bg-primary); color: var(--text-primary);
+  cursor: pointer; transition: all 0.15s ease; white-space: nowrap;
+}
+.bmc-action-btn:hover { background: var(--bg-tertiary); }
+.bmc-action-btn--icon { padding: 6px 8px; color: var(--text-secondary); }
+
+.bmc-more-menu { position: relative; }
+.bmc-more-dropdown {
+  position: absolute; right: 0; top: calc(100% + 4px); z-index: 100;
+  min-width: 180px; background: var(--bg-primary);
+  border: 1px solid var(--border-primary); border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1); padding: 4px;
+}
+.bmc-more-item {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; padding: 8px 10px; border-radius: 6px;
+  font-size: 13px; font-weight: 500; border: none;
+  background: transparent; cursor: pointer; transition: background 0.15s;
+  color: var(--text-primary); text-align: left;
+}
+.bmc-more-item:hover { background: var(--bg-secondary); }
+.bmc-more-item--danger { color: #dc2626; }
+.bmc-more-item--danger:hover { background: #fee2e2; }
+</style>

--- a/src/js/Components/Subscriptions/Subscriptions.vue
+++ b/src/js/Components/Subscriptions/Subscriptions.vue
@@ -1,0 +1,336 @@
+<template>
+  <div class="relative min-h-[200px]">
+    <CoffeeLoader :loading="loading" />
+    <PageTitle title="Subscriptions" subtitle="Manage recurring donations" />
+
+    <!-- Status Pills -->
+    <div v-if="!loading" class="flex flex-wrap gap-2 mb-6">
+      <button
+        v-for="pill in statusPills"
+        :key="pill.value"
+        class="bmc-pill"
+        :class="{ 'bmc-pill--active': filter_status === pill.value }"
+        @click="filter_status = pill.value; current = 0; getSubscriptions()"
+      >
+        {{ pill.label }}
+        <span class="bmc-pill__count">{{ pill.count }}</span>
+      </button>
+    </div>
+
+    <!-- Table Card -->
+    <div class="bg-white rounded-xl border border-neutral-200 shadow-xs p-6">
+      <!-- Filters Row -->
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
+        <div class="relative">
+          <Search :size="16" class="bmc-search-icon" />
+          <input
+            v-model="search"
+            type="text"
+            placeholder="Search by name or email..."
+            class="bmc-search-input"
+            @keyup.enter="current = 0; getSubscriptions()"
+          />
+        </div>
+      </div>
+
+      <!-- Table -->
+      <div v-loading="fetching">
+        <el-table
+          v-if="subscriptions.length"
+          :data="subscriptions"
+          style="width: 100%"
+          :show-header="true"
+          row-class-name="bmc-table-row bmc-table-row--clickable"
+          @row-click="(row) => $router.push({ name: 'SubscriptionDetail', params: { id: row.id } })"
+        >
+          <el-table-column label="Supporter" min-width="200">
+            <template #default="{ row }">
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="row.supporters_image"
+                  :src="row.supporters_image"
+                  :alt="row.supporters_name"
+                  class="bmc-avatar"
+                />
+                <div v-else class="bmc-avatar-placeholder">
+                  {{ getInitials(row.supporters_name) }}
+                </div>
+                <div class="min-w-0">
+                  <p class="bmc-name">{{ row.supporters_name || 'Anonymous' }}</p>
+                  <p class="bmc-email" v-if="row.supporters_email">{{ row.supporters_email }}</p>
+                </div>
+              </div>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="Amount" width="140">
+            <template #default="{ row }">
+              <span class="bmc-amount">{{ formatAmount(row.amount, row.currency) }}</span>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="Interval" width="110">
+            <template #default="{ row }">
+              <span class="bmc-interval">{{ row.interval_type === 'year' ? 'Yearly' : 'Monthly' }}</span>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="Status" width="130">
+            <template #default="{ row }">
+              <span class="bmc-status-badge" :class="'bmc-status-badge--' + row.status">
+                {{ statusLabel(row.status) }}
+              </span>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="Next Renewal" width="160">
+            <template #default="{ row }">
+              <span class="bmc-date">{{ formatDate(row.current_period_end) }}</span>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="Started" width="140">
+            <template #default="{ row }">
+              <span class="bmc-date">{{ formatDate(row.created_at) }}</span>
+            </template>
+          </el-table-column>
+
+          <el-table-column label="" width="60" fixed="right">
+            <template #default="{ row }">
+              <a
+                v-if="row.stripe_subscription_id"
+                :href="stripeSubUrl(row)"
+                target="_blank"
+                rel="noopener"
+                class="bmc-btn-action bmc-btn-link"
+                title="View on Stripe"
+                @click.stop
+              >
+                <ExternalLink :size="14" />
+              </a>
+            </template>
+          </el-table-column>
+        </el-table>
+
+        <EmptyState
+          v-else-if="!fetching"
+          title="No subscriptions yet"
+          description="Recurring subscriptions will appear here once supporters enable the recurring option at checkout."
+          icon="RefreshCw"
+        />
+      </div>
+
+      <!-- Pagination -->
+      <div v-if="total > 0" class="bmc-pagination">
+        <span class="bmc-pagination__info">
+          Showing {{ paginationStart }}–{{ paginationEnd }} of {{ total }}
+        </span>
+        <div class="flex items-center gap-1">
+          <button class="bmc-pagination__btn" :disabled="current === 0" @click="current--; getSubscriptions()">
+            <ChevronLeft :size="16" />
+          </button>
+          <button
+            v-for="page in visiblePages"
+            :key="page"
+            class="bmc-pagination__btn"
+            :class="{ 'bmc-pagination__btn--active': page - 1 === current }"
+            @click="current = page - 1; getSubscriptions()"
+          >
+            {{ page }}
+          </button>
+          <button class="bmc-pagination__btn" :disabled="current >= lastPage - 1" @click="current++; getSubscriptions()">
+            <ChevronRight :size="16" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { Search, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-vue-next';
+import PageTitle from '../UI/PageTitle.vue';
+import CoffeeLoader from '../UI/CoffeeLoader.vue';
+import EmptyState from '../UI/EmptyState.vue';
+
+export default {
+  name: 'Subscriptions',
+  components: { Search, ChevronLeft, ChevronRight, ExternalLink, PageTitle, CoffeeLoader, EmptyState },
+  data() {
+    return {
+      current: 0,
+      total: 0,
+      posts_per_page: 10,
+      search: '',
+      filter_status: 'all',
+      loading: false,
+      fetching: false,
+      subscriptions: [],
+      stats: { active_count: 0, mrr: 0 },
+    };
+  },
+  computed: {
+    lastPage() { return Math.ceil(this.total / this.posts_per_page) || 1; },
+    paginationStart() { return this.total === 0 ? 0 : this.current * this.posts_per_page + 1; },
+    paginationEnd() {
+      const end = (this.current + 1) * this.posts_per_page;
+      return end > this.total ? this.total : end;
+    },
+    visiblePages() {
+      const pages = [];
+      const total = this.lastPage;
+      const current = this.current + 1;
+      let start = Math.max(1, current - 2);
+      let end = Math.min(total, start + 4);
+      if (end - start < 4) start = Math.max(1, end - 4);
+      for (let i = start; i <= end; i++) pages.push(i);
+      return pages;
+    },
+    statusPills() {
+      return [
+        { label: 'All',       value: 'all',       count: this.total },
+        { label: 'Active',    value: 'active',    count: this.stats.active_count || 0 },
+        { label: 'Cancelled', value: 'cancelled', count: 0 },
+        { label: 'Past Due',  value: 'past_due',  count: 0 },
+      ];
+    },
+  },
+  methods: {
+    getSubscriptions() {
+      this.fetching = true;
+      this.$get({
+        action: 'buymecoffee_admin_ajax',
+        route: 'get_subscriptions',
+        data: {
+          search: this.search,
+          filter_status: this.filter_status,
+          page: this.current,
+          posts_per_page: this.posts_per_page,
+        },
+        buymecoffee_nonce: window.BuyMeCoffeeAdmin.buymecoffee_nonce,
+      }).then((response) => {
+        this.subscriptions = response?.data?.subscriptions || [];
+        this.total         = response?.data?.total || 0;
+      }).fail((error) => {
+        this.$handleError(error);
+      }).always(() => {
+        this.fetching = false;
+      });
+    },
+    getStats() {
+      this.$get({
+        action: 'buymecoffee_admin_ajax',
+        route: 'get_subscription_stats',
+        buymecoffee_nonce: window.BuyMeCoffeeAdmin.buymecoffee_nonce,
+      }).then((response) => {
+        if (response?.data) this.stats = response.data;
+      });
+    },
+    formatAmount(cents, currency) {
+      if (!cents) return '--';
+      const symbol = currency ? currency.toUpperCase() : 'USD';
+      return (cents / 100).toFixed(2) + ' ' + symbol;
+    },
+    formatDate(dateStr) {
+      if (!dateStr || dateStr === '0000-00-00 00:00:00') return '--';
+      return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    },
+    statusLabel(status) {
+      const labels = { active: 'Active', cancelled: 'Cancelled', incomplete: 'Incomplete', past_due: 'Past Due' };
+      return labels[status] || status;
+    },
+    getInitials(name) {
+      if (!name) return '?';
+      return name.split(' ').map(w => w[0]).slice(0, 2).join('').toUpperCase();
+    },
+    stripeSubUrl(row) {
+      const mode = row.payment_mode === 'live' ? '' : 'test/';
+      return 'https://dashboard.stripe.com/' + mode + 'subscriptions/' + row.stripe_subscription_id;
+    },
+  },
+  mounted() {
+    this.getSubscriptions();
+    this.getStats();
+  },
+};
+</script>
+
+<style scoped>
+.bmc-avatar { width: 36px; height: 36px; border-radius: 9999px; object-fit: cover; flex-shrink: 0; }
+.bmc-avatar-placeholder {
+  display: flex; align-items: center; justify-content: center;
+  width: 36px; height: 36px; border-radius: 9999px;
+  background: var(--color-primary-50); color: var(--color-primary-600);
+  font-size: 13px; font-weight: 600; flex-shrink: 0;
+}
+.bmc-name { font-size: 14px; font-weight: 500; color: var(--text-primary); margin: 0; }
+.bmc-email { font-size: 12px; color: var(--text-secondary); margin: 1px 0 0; }
+.bmc-amount { font-size: 14px; font-weight: 600; color: var(--text-primary); }
+.bmc-interval { font-size: 13px; color: var(--text-secondary); }
+.bmc-date { font-size: 13px; color: var(--text-secondary); }
+
+.bmc-status-badge {
+  display: inline-flex; align-items: center;
+  padding: 2px 10px; border-radius: 9999px;
+  font-size: 12px; font-weight: 500;
+  background: var(--color-neutral-100); color: var(--text-secondary);
+}
+.bmc-status-badge--active    { background: #dcfce7; color: #166534; }
+.bmc-status-badge--cancelled { background: #fee2e2; color: #991b1b; }
+.bmc-status-badge--incomplete{ background: #fef9c3; color: #854d0e; }
+.bmc-status-badge--past_due  { background: #ffedd5; color: #9a3412; }
+
+.bmc-btn-action {
+  padding: 4px 10px; border-radius: 6px; font-size: 12px; font-weight: 500;
+  border: 1px solid var(--border-primary); background: var(--bg-primary);
+  color: var(--text-primary); cursor: pointer; transition: all 0.15s ease;
+}
+.bmc-btn-action:hover { background: var(--bg-tertiary); }
+.bmc-btn-action--danger { color: #dc2626; border-color: #fca5a5; }
+.bmc-btn-action--danger:hover { background: #fee2e2; }
+.bmc-btn-link { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; color: var(--text-secondary); }
+
+/* Status pills */
+.bmc-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 14px; border-radius: var(--radius-full);
+  font-size: var(--text-sm); font-weight: 500; font-family: var(--font-sans);
+  border: 1px solid var(--border-primary); background: var(--bg-primary);
+  color: var(--text-secondary); cursor: pointer; transition: all 0.15s ease;
+}
+.bmc-pill:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.bmc-pill--active { background: var(--color-primary-50); color: var(--color-primary-700); border-color: var(--color-primary-300); }
+.bmc-pill__count {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 20px; height: 20px; padding: 0 5px;
+  border-radius: 9999px; font-size: 11px; font-weight: 600;
+  background: var(--color-neutral-100); color: var(--text-secondary);
+}
+
+/* Search */
+.bmc-search-icon { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); color: var(--text-tertiary); pointer-events: none; }
+.bmc-search-input {
+  width: 280px; padding: 7px 12px 7px 32px;
+  border: 1px solid var(--border-primary); border-radius: var(--radius-md);
+  font-size: var(--text-base); color: var(--text-primary); background: var(--bg-primary); outline: none;
+}
+.bmc-search-input:focus { border-color: var(--border-focus); box-shadow: var(--shadow-ring); }
+
+/* Pagination */
+.bmc-pagination { display: flex; align-items: center; justify-content: space-between; padding-top: 16px; margin-top: 16px; border-top: 1px solid var(--border-secondary); }
+.bmc-pagination__info { font-size: var(--text-sm); color: var(--text-secondary); }
+.bmc-pagination__btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 32px; height: 32px; padding: 0 6px;
+  border: 1px solid var(--border-primary); border-radius: var(--radius-md);
+  background: var(--bg-primary); color: var(--text-secondary);
+  font-size: var(--text-sm); cursor: pointer; transition: all 0.15s ease;
+}
+.bmc-pagination__btn:hover:not(:disabled) { background: var(--bg-tertiary); }
+.bmc-pagination__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.bmc-pagination__btn--active { background: var(--color-primary-500); color: var(--text-inverse); border-color: var(--color-primary-500); }
+
+/* Clickable rows */
+:deep(.bmc-table-row--clickable) { cursor: pointer; }
+:deep(.bmc-table-row--clickable:hover td) { background: var(--bg-secondary) !important; }
+</style>

--- a/src/js/Components/Supporter.vue
+++ b/src/js/Components/Supporter.vue
@@ -61,8 +61,8 @@
               Send Email
             </a>
             <a
-              v-if="supporter.transaction_url"
-              :href="supporter.transaction_url"
+              v-if="supporter.transaction && supporter.transaction.transaction_url"
+              :href="supporter.transaction.transaction_url"
               target="_blank"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-neutral-200 no-underline transition-colors"
               style="color: var(--text-primary); background: var(--bg-primary)"
@@ -141,7 +141,22 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-y-4 gap-x-6">
           <div v-if="supporter.transaction.charge_id">
             <p class="text-xs mb-1 m-0" style="color: var(--text-tertiary)">Transaction ID</p>
-            <p class="text-sm font-medium m-0" style="color: var(--text-primary)">{{ supporter.transaction.charge_id }}</p>
+            <p class="text-sm font-medium m-0">
+              <a
+                v-if="supporter.transaction.transaction_url"
+                :href="supporter.transaction.transaction_url"
+                target="_blank"
+                rel="noopener"
+                class="inline-flex items-center gap-1 font-mono no-underline hover:underline"
+                style="color: var(--color-primary-600); font-size: 13px"
+              >
+                {{ supporter.transaction.charge_id }}
+                <ExternalLink :size="11" />
+              </a>
+              <span v-else class="font-mono" style="color: var(--text-primary); font-size: 13px">
+                {{ supporter.transaction.charge_id }}
+              </span>
+            </p>
           </div>
           <div v-if="supporter.transaction.card_brand">
             <p class="text-xs mb-1 m-0" style="color: var(--text-tertiary)">Card</p>
@@ -156,7 +171,7 @@
           </div>
           <div v-if="supporter.transaction.status">
             <p class="text-xs mb-1 m-0" style="color: var(--text-tertiary)">Gateway Status</p>
-            <p class="text-sm font-medium m-0" style="color: var(--text-primary)">{{ supporter.transaction.status }}</p>
+            <StatusBadge :status="supporter.transaction.status" />
           </div>
           <div v-if="supporter.payment_mode">
             <p class="text-xs mb-1 m-0" style="color: var(--text-tertiary)">Mode</p>

--- a/src/js/Components/UI/AppSidebar.vue
+++ b/src/js/Components/UI/AppSidebar.vue
@@ -102,6 +102,7 @@ import {
     LayoutDashboard, Heart, Settings, Palette, Code2,
     CreditCard, Bell, ExternalLink, Sparkles, ArrowLeft,
     ChevronsLeft, ChevronsRight, ChevronDown, ChevronRight,
+    RefreshCw,
 } from 'lucide-vue-next';
 
 const COLLAPSE_KEY = '__buymecoffee_sidebar_collapsed';
@@ -119,8 +120,9 @@ const wpAdminUrl = computed(() => (window.BuyMeCoffeeAdmin?.wp_admin_url || '/wp
 const isWpAdmin = computed(() => !!window.BuyMeCoffeeAdmin?.is_wp_admin);
 
 const mainItems = [
-    { label: 'Dashboard', route: '/', icon: LayoutDashboard, activeNames: ['Dashboard'] },
-    { label: 'Supporters', route: '/supporters', icon: Heart, activeNames: ['Supporters', 'Supporter'] },
+    { label: 'Dashboard',     route: '/',             icon: LayoutDashboard, activeNames: ['Dashboard'] },
+    { label: 'Supporters',    route: '/supporters',   icon: Heart,           activeNames: ['Supporters', 'Supporter'] },
+    { label: 'Subscriptions', route: '/subscriptions', icon: RefreshCw,      activeNames: ['Subscriptions', 'SubscriptionDetail'] },
 ];
 
 const configItems = [

--- a/src/js/PaymentMethods/stripe-checkout.js
+++ b/src/js/PaymentMethods/stripe-checkout.js
@@ -1,9 +1,13 @@
+import BmcCoffeeLoader from '../utils/coffeeLoader.js';
+
 class StripeCheckout {
     constructor ($form, $response) {
-        this.form = $form;
-        this.data = $response.data;
-        this.intent = $response.data?.intent;
-        this.parentWrapper = this.form.parents('.bmc-form-card, .buymecoffee_form_preview_wrapper').first();
+        this.form           = $form;
+        this.data           = $response.data;
+        this.intent         = $response.data?.intent;
+        this.subscriptionId = $response.data?.subscription_id || null;
+        this.parentWrapper  = this.form.parents('.bmc-form-card, .buymecoffee_form_preview_wrapper').first();
+        this.loader         = new BmcCoffeeLoader(this.parentWrapper[0]);
     }
 
     init () {
@@ -20,34 +24,41 @@ class StripeCheckout {
         paymentElement.mount(formSelector);
 
         let self= this;
-        paymentElement.on('ready', (event) => {
+        paymentElement.on('ready', () => {
             this.afterPaymentProcessorReady(payButton);
             this.form.find('#buymecoffee_pay_now').on('click', function(e) {
-                e.preventDefault()
-                const originalLabel = jQuery(this).text();
-                jQuery(this).text('Processing...');
-                elements.submit().then(result=> {
+                e.preventDefault();
+                jQuery(this).attr('disabled', true);
+                self.loader.show('Processing your payment...');
+                elements.submit().then(() => {
                     stripe.confirmPayment({
                         elements,
                         confirmParams: {},
                         redirect: 'if_required'
                     }).then((result) => {
-                        jQuery(this).text('Redirecting...');
+                        if (result.error) {
+                            self.loader.hide();
+                            jQuery('#buymecoffee_pay_now').removeAttr('disabled');
+                            return;
+                        }
                         self.afterPaymentSuccess();
-                        //update payment data into DB
                         if (result?.paymentIntent?.id) {
-                            jQuery.post(window.buymecoffee_general.ajax_url, {
+                            const confirmPayload = {
                                 action: 'buymecoffee_payment_confirmation_stripe',
                                 buymecoffee_nonce: window.buymecoffee_general?.buymecoffee_nonce || '',
-                                intentId: result?.paymentIntent?.id,
-                            })
+                                intentId: result.paymentIntent.id,
+                            };
+                            if (self.subscriptionId) {
+                                confirmPayload.subscriptionId = self.subscriptionId;
+                            }
+                            jQuery.post(window.buymecoffee_general.ajax_url, confirmPayload);
                         }
-                    })
-                }).catch(error => {
-                    console.log(error, 'kk')
-                    jQuery(this).text(originalLabel);
-                })
-            })
+                    });
+                }).catch(() => {
+                    self.loader.hide();
+                    jQuery('#buymecoffee_pay_now').removeAttr('disabled');
+                });
+            });
         });
     }
     generatePayButton() {
@@ -56,21 +67,26 @@ class StripeCheckout {
         return "<button id='buymecoffee_pay_now' type='submit'>" + buttonText + "</button>";
     }
     startPaymentProcessing() {
-        this.form.find('.buymecoffee_payment_processor').parent().prepend("<p class='buymecoffee_loading_processor'>Payment processor loading...<p/>");
-        this.form.find('.buymecoffee_input_content, .buymecoffee_pay_methods, .buymecoffee_payment_item, .buymecoffee_form_submit_wrapper, .buymecoffee_no_signup').hide();
+        this.form.find('.buymecoffee_input_content, .buymecoffee_pay_methods, .buymecoffee_payment_item, .buymecoffee_form_submit_wrapper, .buymecoffee_no_signup, .buymecoffee_recurring_section').hide();
+        this.loader.show('Setting up payment...');
     }
 
     afterPaymentSuccess() {
+        this.loader.hide();
+        const isSubscription = !!this.data?.is_subscription;
+        const message = isSubscription
+            ? "Recurring donation set up successfully 🖤"
+            : "Thanks for your contribution 🖤";
         const receipt = "<a href='" + this.data?.order_items?.payment_args?.success_url + "'>View Receipt</a>";
-        this.parentWrapper.append("<div class='buymecoffee_form_receipt'>Thanks for your contribution 🖤<br/>" + receipt + "</div>");
+        this.parentWrapper.append("<div class='buymecoffee_form_receipt'>" + message + "<br/>" + receipt + "</div>");
         this.parentWrapper.find('.buymecoffee_form').hide();
         this.parentWrapper.find('.buymecoffee_form_to, .bmc-form-card__title').hide();
     }
 
     afterPaymentProcessorReady(payButton) {
+        this.loader.hide();
         this.form.prepend("<p class='complete_payment_instruction'>Please complete your donation with Stripe 👇</p>");
         this.form.find('.buymecoffee_payment_processor').append(payButton);
-        this.form.find('.buymecoffee_loading_processor').remove();
     }
   }
   

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -9,6 +9,8 @@ import Supporters from './Components/Supporters.vue';
 import Notifications from './Components/Notifications.vue'
 import Emails from "./Components/Email/Emails.vue";
 import Webhook from "./Components/Webhook.vue";
+import Subscriptions from './Components/Subscriptions/Subscriptions.vue';
+import SubscriptionDetail from './Components/Subscriptions/SubscriptionDetail.vue';
 
 export default [
     {
@@ -106,5 +108,22 @@ export default [
             breadcrumb: 'Quick Setup'
         },
         exact: true
+    },
+    {
+        path: '/subscriptions',
+        name: 'Subscriptions',
+        component: Subscriptions,
+        meta: {
+            active: 'subscriptions',
+            breadcrumb: 'Subscriptions'
+        }
+    },
+    {
+        path: '/subscriptions/:id',
+        name: 'SubscriptionDetail',
+        component: SubscriptionDetail,
+        meta: {
+            breadcrumb: 'Subscription Detail'
+        }
     }
 ];

--- a/src/js/utils/coffeeLoader.js
+++ b/src/js/utils/coffeeLoader.js
@@ -1,0 +1,67 @@
+const CUP_SVG = `<svg width="72" height="72" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
+  <path class="bmc-steam bmc-steam--1" d="M38 38 C40 30 36 22 38 14" stroke="#C9BFB2" stroke-width="2.5" stroke-linecap="round"/>
+  <path class="bmc-steam bmc-steam--2" d="M50 36 C52 28 48 20 50 12" stroke="#C9BFB2" stroke-width="2.5" stroke-linecap="round"/>
+  <path class="bmc-steam bmc-steam--3" d="M62 38 C64 30 60 22 62 14" stroke="#C9BFB2" stroke-width="2.5" stroke-linecap="round"/>
+  <ellipse cx="50" cy="90" rx="36" ry="5.5" fill="#E8E0D8"/>
+  <ellipse cx="50" cy="89" rx="30" ry="3.5" fill="#F0E8E0"/>
+  <path d="M25 42 L25 78 Q25 87 34 87 L66 87 Q75 87 75 78 L75 42 Z" fill="#FAFAF9" stroke="#D6D3D1" stroke-width="1.5"/>
+  <path d="M27 48 L27 78 Q27 85 34 85 L66 85 Q73 85 73 78 L73 48 Z" fill="#5C3D2E"/>
+  <path d="M27 48 Q38 44 50 48 Q62 52 73 48" fill="#7B5341"/>
+  <path d="M47 63 C47 60 50 58 50 61 C50 58 53 60 53 63 C53 66 50 70 50 70 C50 70 47 66 47 63" fill="#7B5341" opacity="0.6">
+    <animate attributeName="opacity" values="0.4;0.8;0.4" dur="2.5s" repeatCount="indefinite"/>
+  </path>
+  <path d="M75 50 Q91 50 91 64 Q91 78 75 78" stroke="#D6D3D1" stroke-width="2.5" stroke-linecap="round"/>
+</svg>`;
+
+const MESSAGES = [
+    'Brewing your payment...',
+    'Pouring a fresh cup...',
+    'Warming things up...',
+    'Almost ready...',
+    'Steaming ahead...',
+];
+
+class BmcCoffeeLoader {
+    constructor(wrapper) {
+        // wrapper: a DOM element (the .bmc-form-card or similar)
+        this.wrapper = wrapper;
+        this.el      = null;
+        this.timer   = null;
+        this.msgIdx  = 0;
+    }
+
+    show(message) {
+        if (this.el) return;
+        this.msgIdx = Math.floor(Math.random() * MESSAGES.length);
+        const msg = message || MESSAGES[this.msgIdx];
+
+        this.el = document.createElement('div');
+        this.el.className = 'bmc-pub-loader';
+        this.el.innerHTML = `
+            <div class="bmc-pub-loader__inner">
+                <div class="bmc-pub-loader__cup">${CUP_SVG}</div>
+                <p class="bmc-pub-loader__msg">${msg}</p>
+            </div>`;
+
+        this.wrapper.style.position = 'relative';
+        this.wrapper.appendChild(this.el);
+
+        // cycle messages every 2.4 s
+        this.timer = setInterval(() => {
+            this.msgIdx = (this.msgIdx + 1) % MESSAGES.length;
+            const p = this.el && this.el.querySelector('.bmc-pub-loader__msg');
+            if (p) p.textContent = MESSAGES[this.msgIdx];
+        }, 2400);
+    }
+
+    hide() {
+        clearInterval(this.timer);
+        this.timer = null;
+        if (this.el) {
+            this.el.remove();
+            this.el = null;
+        }
+    }
+}
+
+export default BmcCoffeeLoader;

--- a/src/scss/public/BasicTemplate.scss
+++ b/src/scss/public/BasicTemplate.scss
@@ -292,6 +292,7 @@ $bmc-radius: 16px;
 
 // ── Form Card ──────────────────────────────────
 .bmc-form-card {
+  position: relative;
   background: #fff;
   border-radius: $bmc-radius;
   padding: 32px 28px;
@@ -576,6 +577,45 @@ $bmc-radius: 16px;
   margin-bottom: 16px !important;
 }
 
+.bmc_field_error input {
+  border-color: #ef4444 !important;
+  outline-color: #ef4444 !important;
+
+  &::placeholder {
+    color: #ef4444 !important;
+    opacity: 1;
+  }
+}
+
+.buymecoffee_recurring_section {
+  margin-bottom: 12px;
+
+  .buymecoffee_recurring_label {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #3f3f46;
+    cursor: pointer;
+    user-select: none;
+
+    input[type='checkbox'] {
+      width: 15px;
+      height: 15px;
+      cursor: pointer;
+      flex-shrink: 0;
+      accent-color: currentColor;
+    }
+  }
+
+  .buymecoffee_recurring_hint {
+    font-size: 11px;
+    color: #a1a1aa;
+    font-weight: 400;
+  }
+}
+
 .buymecoffee_pay_method {
   display: flex;
   gap: 10px;
@@ -724,6 +764,35 @@ form.wpm_submitting_form {
     font-size: 13px;
     color: #52525b;
     margin: 0;
+  }
+
+  &__recurring-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 6px;
+    padding: 3px 10px;
+    border-radius: 9999px;
+    background: #d1fae5;
+    color: #065f46;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  &__type-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-size: 12px;
+    font-weight: 500;
+
+    &--recurring {
+      background: #d1fae5;
+      color: #065f46;
+    }
   }
 
   // ── Amount box ──
@@ -952,4 +1021,67 @@ form.wpm_submitting_form {
     width: 48px !important;
     height: 40px !important;
   }
+}
+
+// ── Coffee Loader (public) ───────────────────────────────────────────────────
+.bmc-pub-loader {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  border-radius: inherit;
+
+  &__inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+  }
+
+  &__cup {
+    width: 72px;
+    height: 72px;
+    flex-shrink: 0;
+    animation: bmc-pub-bob 2.8s ease-in-out infinite;
+
+    svg {
+      display: block;
+      width: 72px;
+      height: 72px;
+      overflow: visible;
+    }
+  }
+
+  &__msg {
+    font-size: 13px;
+    font-weight: 500;
+    color: #6b7280;
+    margin: 0;
+    letter-spacing: 0.01em;
+    animation: bmc-pub-pulse 2.4s ease-in-out infinite;
+  }
+}
+
+@keyframes bmc-pub-bob {
+  0%, 100% { transform: translateY(0); }
+  50%       { transform: translateY(-5px); }
+}
+
+@keyframes bmc-pub-pulse {
+  0%, 100% { opacity: 0.6; }
+  50%       { opacity: 1; }
+}
+
+.bmc-pub-loader .bmc-steam        { animation: bmc-pub-steam 2s ease-out infinite; }
+.bmc-pub-loader .bmc-steam--2     { animation-delay: 0.45s; }
+.bmc-pub-loader .bmc-steam--3     { animation-delay: 0.9s; }
+
+@keyframes bmc-pub-steam {
+  0%   { opacity: 0;    transform: translateY(0) scaleY(0.4); }
+  25%  { opacity: 0.55; }
+  100% { opacity: 0;    transform: translateY(-12px) scaleY(1.15); }
 }


### PR DESCRIPTION
**What does this PR do and why?**
                                                                                                          
  Adds Stripe Subscription (recurring donation) support to the plugin. Supporters can now opt into monthly
   or yearly recurring payments at checkout; admins get a dedicated Subscriptions list page, a            
  detail/cancel view, and two new Dashboard stat cards (Active Subscriptions, MRR). The feature required a
   new buymecoffee_subscriptions DB table, a DB version migration system for existing installs, and a     
  live/webhook dual-path activation strategy so subscriptions reach active status reliably with or without
   webhooks configured.                                                                                 
                                                                                                          
  ---
  **Changes**
         
  - PHP (backend logic, models, services, hooks)
  - Vue/React (admin UI)                                                                                  
  - CSS/Tailwind (styling)                                                                                
  - Database (migrations, schema changes)                                                                 
  - Build/config (new JS entry point coffeeLoader.js, Vite bundle)                                        
                                                                                                          
  ---                                                                                                     
  **How to test**                                                                                             
                                                                                                        
  Recurring checkout                                                                                    
  1. Go to /?share_coffee, select Stripe as payment method.                                               
  2. Check "Make it recurring" — email field should slide in and interval hint appear next to checkbox.   
  3. Submit without email → red validation error should block submit.                                     
  4. Fill in email, submit → Stripe Elements card form appears with coffee loader overlay.                
  5. Pay with test card 4242 4242 4242 4242 → success receipt shows "Recurring donation set up            
  successfully".                                                                                          
  6. In wp-admin → Buy Me Coffee → Subscriptions → new row appears with status Active (not Incomplete).   
                                                                                                          
  Admin Subscriptions page                                                                                
  7. Navigate to Subscriptions in the sidebar → list renders with supporter name, amount, interval, status
   badge, next renewal, and an external link icon to Stripe dashboard.                                    
  8. Clicking any row navigates to the subscription detail page.                                          
  9. In the detail page, three-dot menu → "Cancel Subscription" → popconfirm (260 px wide) → confirm →    
  status flips to Cancelled on Stripe and locally.                                                        
  10. "View on Stripe" button opens correct Stripe dashboard URL (test vs live).                          
                                                                                                          
  Webhook fallback                                                                                      
  11. Using Stripe CLI: stripe trigger invoice.payment_succeeded with a linked subscription → renewal     
  transaction row created, subscription current_period_end updated.                                       
  12. stripe trigger customer.subscription.deleted → local status set to cancelled.                     
                                                                                                          
  Dashboard stats                                                 
  13. Active Subscriptions and Monthly Recurring Revenue cards show correct values after step 6.          
                                                                                                          
  Migration (existing installs)                                                                         
  14. On an install that already has supporters/transactions tables (no subscriptions table), deactivate  
  and reactivate the plugin (or let plugins_loaded fire) → buymecoffee_subscriptions table is created     
  automatically; buymecoffee_db_version option is set to 1.3.                                           
                                                                                                          
  ---                                                             
  **Screenshots**                                                                                           
             
  Before/after UI changes present (Subscriptions list, detail page, Dashboard MRR cards, public coffee
  loader, recurring checkbox on checkout form).                                                           
   
  ---                                                                                                     
  **Anything the reviewer should know?**                              
                                                                                                        
  Subscription activation — dual path (Stripe.php:82–108, PaymentHelper.php:69–76): The primary activation
   happens in paymentConfirmation() — JS passes the local subscription_id in the confirmation AJAX call   
  and PHP immediately sets status to active before even re-querying Stripe. updatePaymentData() then runs
  as a secondary pass to record charge/card details and also activates the subscription if subscription_id
   is on the transaction (covers webhook-less setups). The invoice.payment_succeeded webhook with
  billing_reason=subscription_create is the final fallback.                                             

  Stripe metadata propagation bug (StripeSubscriptions.php:98–103): Stripe does not propagate subscription
   metadata to its child PaymentIntent. A second API call explicitly stamps ref_id on the PI so
  updatePaymentData() can locate the local order by hash.                                                 
                                                                  
  Product caching (StripeSubscriptions.php:158–179): A single Stripe product is created per mode          
  (test/live) and its ID is cached in wp_options (buymecoffee_stripe_recurring_product_{mode}). Reviewers
  should be aware this option persists after deactivation; if the product is deleted in Stripe the option 
  must be cleared manually.                                       
                                                                                                        
  Public coffee loader (src/js/utils/coffeeLoader.js): A shared vanilla-JS class imported by both         
  BmcFormHandler.js and stripe-checkout.js. The admin CoffeeLoader.vue could not be reused on the public
  page (no Vue runtime there), so the SVG and animations were ported to a standalone utility +            
  BasicTemplate.scss styles.