### PR TITLE
Dedicated access managements

### DIFF
--- a/buy-me-coffee.php
+++ b/buy-me-coffee.php
@@ -42,7 +42,7 @@ if (!defined('BUYMECOFFEE_VERSION')) {
     if (!defined('BUYMECOFFEE_PRODUCTION')) {
         define('BUYMECOFFEE_PRODUCTION', false);
     }
-    define('BUYMECOFFEE_DB_VERSION', '1.9');
+    define('BUYMECOFFEE_DB_VERSION', '1.12');
 
     // if (!defined('BUYMECOFFEE_DEBUG')) {
     //     define('BUYMECOFFEE_DEBUG', false);

--- a/includes/Builder/Methods/Stripe/Stripe.php
+++ b/includes/Builder/Methods/Stripe/Stripe.php
@@ -7,6 +7,7 @@ use BuyMeCoffee\Classes\ActivityLogger;
 use BuyMeCoffee\Classes\Vite;
 use BuyMeCoffee\Helpers\ArrayHelper;
 use BuyMeCoffee\Helpers\PaymentHelper;
+use BuyMeCoffee\Models\MembershipAccess;
 use BuyMeCoffee\Models\Subscriptions;
 use BuyMeCoffee\Models\Supporters;
 use BuyMeCoffee\Models\Transactions;
@@ -77,6 +78,13 @@ class Stripe extends BaseMethods
             }
             (new StripeSubscriptions())->createSubscription($transaction, $paymentArgs, $apiKey, $interval);
         } else {
+            if (!empty($paymentArgs['bmc_level_id'])) {
+                $membershipAccessId = $this->createOneTimeMembershipAccess($transaction, $paymentArgs);
+                if ($membershipAccessId) {
+                    $paymentArgs['membership_access_id'] = $membershipAccessId;
+                }
+            }
+
             $this->handleInlinePayment($transaction, $paymentArgs, $apiKey);
         }
     }
@@ -105,11 +113,17 @@ class Stripe extends BaseMethods
 
         // Fallback / full update: re-query Stripe to record charge details, card info, etc.
         // Also activates subscription if subscription_id is on the transaction (covers webhook-less setups).
-        (new PaymentHelper())->updatePaymentData($intentId);
+        $paymentResult = (new PaymentHelper())->updatePaymentData($intentId);
 
-        wp_send_json_success([
-            'message' => __('Payment confirmation received', 'buy-me-coffee')
-        ], 200);
+        if (is_wp_error($paymentResult)) {
+            wp_send_json_error([
+                'message' => $paymentResult->get_error_message(),
+            ], 400);
+        }
+
+        wp_send_json_success(wp_parse_args((array) $paymentResult, [
+            'message' => __('Payment confirmation received', 'buy-me-coffee'),
+        ]), 200);
     }
 
     private function activateMatchedSubscription($intentId, $requestedSubscriptionId)
@@ -187,6 +201,22 @@ class Stripe extends BaseMethods
 
         if (!$orderHash && !$this->intentBelongsToSubscription($intentId, $localSubscription)) {
             return false;
+        }
+
+        if ($intentStatus !== 'succeeded') {
+            (new Supporters())->updateData((int) $supporter->id, [
+                'payment_status' => 'pending',
+                'updated_at'     => current_time('mysql'),
+            ]);
+            (new Transactions())->updateData((int) $transaction->id, [
+                'status'       => 'pending',
+                'charge_id'    => sanitize_text_field($intentId),
+                'payment_mode' => !empty($intent['livemode']) ? 'live' : 'test',
+                'payment_note' => wp_json_encode($intent),
+                'updated_at'   => current_time('mysql'),
+            ]);
+
+            return true;
         }
 
         $update = [
@@ -276,7 +306,6 @@ class Stripe extends BaseMethods
             }
 
             $transaction->payment_args = $paymentArgs;
-
             $responseData = [
                 'nextAction' => 'stripe',
                 'actionName' => 'custom',
@@ -286,6 +315,11 @@ class Stripe extends BaseMethods
                 'message_to_show' => __('Payment Modal is opening, Please complete the payment', 'buy-me-coffee'),
             ];
 
+            if (!empty($paymentArgs['membership_access_id'])) {
+                $responseData['membership_access_id'] = (int) $paymentArgs['membership_access_id'];
+                $responseData['is_membership'] = true;
+            }
+
             wp_send_json_success($responseData, 200);
         } catch (\Exception $e) {
             wp_send_json_error([
@@ -293,6 +327,39 @@ class Stripe extends BaseMethods
                 'message' => $e->getMessage()
             ], 423);
         }
+    }
+
+    private function createOneTimeMembershipAccess($transaction, array $paymentArgs): int
+    {
+        $levelId = !empty($paymentArgs['bmc_level_id']) ? absint($paymentArgs['bmc_level_id']) : 0;
+        if (!$levelId) {
+            return 0;
+        }
+
+        $accessId = (new MembershipAccess())->createPendingForTransaction(
+            (int) $transaction->id,
+            (int) $paymentArgs['supporter_id'],
+            $levelId,
+            'one_time'
+        );
+
+        if (!$accessId) {
+            return 0;
+        }
+
+        ActivityLogger::logMembershipAccess((int) $accessId, 'membership_access_created', 'One-time membership access created', [
+            'status'  => 'info',
+            'context' => [
+                'membership_access_id' => (int) $accessId,
+                'transaction_id'  => (int) $transaction->id,
+                'supporter_id'    => (int) $paymentArgs['supporter_id'],
+                'level_id'        => $levelId,
+                'amount'          => (int) $paymentArgs['amount'],
+                'currency'        => $paymentArgs['currency'],
+            ],
+        ]);
+
+        return (int) $accessId;
     }
 
     public function intentData($args)
@@ -459,6 +526,18 @@ class Stripe extends BaseMethods
             'status' => sanitize_text_field($status),
             'updated_at' => current_time('mysql')
         ]);
+
+        if ($status === 'paid' && !empty($transaction->subscription_id)) {
+            (new Subscriptions())->updateData((int) $transaction->subscription_id, [
+                'status'     => 'active',
+                'updated_at' => current_time('mysql'),
+            ]);
+            do_action('buymecoffee_subscription_activated', (int) $transaction->subscription_id);
+        }
+
+        if ($status === 'paid' && empty($transaction->subscription_id)) {
+            (new MembershipAccess())->activateByTransaction((int) $transaction->id);
+        }
 
         do_action('buymecoffee_payment_status_updated', $transaction->id, $status);
         self::debugLog('updateStatus: done — transaction #' . $transaction->id . ' status updated and action fired');

--- a/includes/Builder/Methods/Stripe/StripeSubscriptions.php
+++ b/includes/Builder/Methods/Stripe/StripeSubscriptions.php
@@ -5,6 +5,7 @@ namespace BuyMeCoffee\Builder\Methods\Stripe;
 use BuyMeCoffee\Models\Subscriptions;
 use BuyMeCoffee\Models\Supporters;
 use BuyMeCoffee\Models\Transactions;
+use BuyMeCoffee\Models\MembershipAccess;
 use BuyMeCoffee\Classes\ActivityLogger;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
@@ -149,6 +150,10 @@ class StripeSubscriptions
             $transaction->payment_args   = $paymentArgs;
             $transaction->subscription_id = (int) $localSubscriptionId;
 
+            if ($levelId) {
+                (new MembershipAccess())->upsertFromSubscription((int) $localSubscriptionId, false);
+            }
+
             wp_send_json_success([
                 'nextAction'      => 'stripe',
                 'actionName'      => 'custom',
@@ -156,6 +161,7 @@ class StripeSubscriptions
                 'intent'          => $paymentIntent,
                 'order_items'     => $transaction,
                 'is_subscription' => true,
+                'is_membership'   => !empty($levelId),
                 'subscription_id' => (int) $localSubscriptionId,
                 'message_to_show' => __('Setting up your recurring donation, please complete the payment below.', 'buy-me-coffee'),
             ], 200);
@@ -250,6 +256,10 @@ class StripeSubscriptions
                 'updated_at'         => current_time('mysql'),
             ]);
 
+            if (!empty($subscription->level_id)) {
+                (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+            }
+
             ActivityLogger::logSubscription((int) $subscription->id, 'subscription_activated', 'Subscription activated', [
                 'status'     => 'success',
                 'created_by' => 'webhook:stripe',
@@ -324,6 +334,10 @@ class StripeSubscriptions
             'updated_at'         => current_time('mysql'),
         ]);
 
+        if (!empty($subscription->level_id)) {
+            (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+        }
+
         ActivityLogger::logSubscription((int) $subscription->id, 'subscription_renewed', 'Subscription renewed', [
             'status'     => 'success',
             'created_by' => 'webhook:stripe',
@@ -370,6 +384,9 @@ class StripeSubscriptions
             'cancelled_at' => current_time('mysql'),
             'updated_at'   => current_time('mysql'),
         ]);
+        if (!empty($subscription->level_id)) {
+            (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+        }
         do_action('buymecoffee_subscription_cancelled', (int) $subscription->id);
 
         ActivityLogger::logSubscription((int) $subscription->id, 'subscription_cancelled', 'Subscription cancelled via Stripe', [
@@ -432,6 +449,9 @@ class StripeSubscriptions
         }
 
         $subscriptionModel->updateData($subscription->id, $update);
+        if (!empty($subscription->level_id)) {
+            (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+        }
         if (!empty($update['status']) && $update['status'] !== $subscription->status) {
             do_action('buymecoffee_subscription_status_changed', (int) $subscription->id, (string) $subscription->status, (string) $update['status']);
         }
@@ -634,6 +654,9 @@ class StripeSubscriptions
 
         // 4. Update local subscription record
         (new Subscriptions())->updateData($subscription->id, $subscriptionUpdate);
+        if (!empty($subscription->level_id)) {
+            (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+        }
 
         ActivityLogger::logSubscription((int) $subscription->id, 'subscription_fetched', 'Subscription fetched from Stripe', [
             'status'  => 'info',

--- a/includes/Builder/Render.php
+++ b/includes/Builder/Render.php
@@ -154,21 +154,29 @@ class Render
         $bmcLevelName = '';
         $bmcLevelPrice = 0;
         $bmcLevelFormattedAmount = '';
+        $bmcLevelPaymentType = 'subscription';
         if (!empty($args['bmc_level'])) {
             $bmcLevel   = $args['bmc_level'];
             $bmcLevelId = absint($bmcLevel->id);
             $bmcLevelName = sanitize_text_field($bmcLevel->name);
             $bmcLevelPrice = (int) $bmcLevel->price;
+            $bmcLevelPaymentType = !empty($bmcLevel->payment_type) && $bmcLevel->payment_type === 'one_time' ? 'one_time' : 'subscription';
             $bmcLevelFormattedAmount = PaymentHelper::getFormattedAmount($bmcLevelPrice, $currency);
             $defaultAmount = $bmcLevelPrice / 100;
             $customCoffeeDefault = $defaultAmount;
-            $allowRecurring   = true;
+            $allowRecurring   = $bmcLevelPaymentType === 'subscription';
             $recurringInterval = sanitize_text_field($bmcLevel->interval_type ?: 'month');
+            $emailAttributes['data-required'] = 'yes';
+            $emailAttributes['placeholder'] = __('Email address', 'buy-me-coffee');
         }
+
+        $submitButtonLabel = $bmcLevelId
+            ? ($bmcLevelPaymentType === 'one_time' ? __('Join', 'buy-me-coffee') : __('Subscribe', 'buy-me-coffee'))
+            : __('Support', 'buy-me-coffee');
 
         ob_start();
         ?>
-        <form id="<?php echo esc_attr($formDynamicClass . '_main_wrapper');  ?>" class="buymecoffee_form<?php echo $bmcLevelId ? ' bmc-level-locked' : ''; ?>" data-wpm_currency="<?php echo esc_html($currency); ?>"<?php echo $bmcLevelId ? ' data-bmc-level-id="' . absint($bmcLevelId) . '"' : ''; ?>>
+        <form id="<?php echo esc_attr($formDynamicClass . '_main_wrapper');  ?>" class="buymecoffee_form<?php echo $bmcLevelId ? ' bmc-level-locked' : ''; ?>" data-wpm_currency="<?php echo esc_html($currency); ?>"<?php echo $bmcLevelId ? ' data-bmc-level-id="' . absint($bmcLevelId) . '" data-bmc-payment-type="' . esc_attr($bmcLevelPaymentType) . '"' : ''; ?>>
             <input type="hidden" name="__buymecoffee_ref" value="<?php echo esc_html($template['yourName']); ?>"/>
             <input type="hidden" name="buymecoffee_quantity" value="1"/>
             <?php if ($bmcLevelId): ?>
@@ -191,7 +199,9 @@ class Render
                 <span class="bmc-level-locked-name"><?php echo esc_html($bmcLevelName); ?></span>
                 <div class="bmc-level-locked-pricing">
                     <span class="bmc-level-locked-amount"><?php echo esc_html($bmcLevelFormattedAmount); ?></span>
+                    <?php if ($bmcLevelPaymentType === 'subscription') : ?>
                     <span class="bmc-level-locked-interval">/<?php echo esc_html($recurringInterval === 'year' ? __('year', 'buy-me-coffee') : __('month', 'buy-me-coffee')); ?></span>
+                    <?php endif; ?>
                 </div>
             </div>
             <?php elseif (!$isCustomPay): ?>
@@ -250,11 +260,11 @@ class Render
             <?php endif; ?>
 
             <?php
-            // Show email field normally, or hidden-but-present when recurring is allowed
-            // (recurring requires an email for the Stripe customer)
-            $emailHiddenForRecurring = !$enableEmail && $allowRecurring;
-            if ($enableEmail || $allowRecurring) : ?>
-                <div data-element_type="email" class="buymecoffee_form_item<?php echo $emailHiddenForRecurring ? ' bmc_email_recurring_only' : ''; ?>"<?php echo $emailHiddenForRecurring ? ' style="display:none;"' : ''; ?>>
+            // Show email field normally, or hidden-but-present when an account is required.
+            $requiresAccountEmail = $allowRecurring || (bool) $bmcLevelId;
+            $emailHiddenForAccount = !$enableEmail && $requiresAccountEmail;
+            if ($enableEmail || $requiresAccountEmail) : ?>
+                <div data-element_type="email" class="buymecoffee_form_item<?php echo $emailHiddenForAccount ? ' bmc_email_recurring_only' : ''; ?>"<?php echo $emailHiddenForAccount ? ' style="display:none;"' : ''; ?>>
                     <div class="buymecoffee_input_content">
                         <input <?php
                         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -301,7 +311,11 @@ class Render
                 <div class="buymecoffee_input_content">
                     <button <?php
                     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                    echo static::builtAttributes($btnAttributes); ?>>Support
+                    echo static::builtAttributes($btnAttributes); ?>
+                            data-default-label="<?php esc_attr_e('Support', 'buy-me-coffee'); ?>"
+                            data-recurring-label="<?php esc_attr_e('Subscribe', 'buy-me-coffee'); ?>"
+                            data-membership-label="<?php echo esc_attr($bmcLevelPaymentType === 'one_time' ? __('Join', 'buy-me-coffee') : __('Subscribe', 'buy-me-coffee')); ?>">
+                        <span class="wpm_submit_button_label"><?php echo esc_html($submitButtonLabel); ?></span>
                         <div class="wpm_loading_svg">
                             <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg"
                                  xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="30px" height="30px"
@@ -320,7 +334,7 @@ class Render
                     </button>
                 </div>
             </div>
-            <p class="buymecoffee_no_signup" data-default="<?php esc_attr_e('No signup required', 'buy-me-coffee'); ?>" data-recurring="<?php esc_attr_e('An account will be created to manage your subscription', 'buy-me-coffee'); ?>"><?php esc_html_e('No signup required', 'buy-me-coffee'); ?></p>
+            <p class="buymecoffee_no_signup" data-default="<?php esc_attr_e('No signup required', 'buy-me-coffee'); ?>" data-recurring="<?php esc_attr_e('An account will be created to manage your subscription', 'buy-me-coffee'); ?>" data-membership="<?php esc_attr_e('An account will be created to manage your membership', 'buy-me-coffee'); ?>"><?php esc_html_e('No signup required', 'buy-me-coffee'); ?></p>
         </form>
         <?php
         return ob_get_clean();

--- a/includes/Classes/AccountPage.php
+++ b/includes/Classes/AccountPage.php
@@ -232,6 +232,8 @@ class AccountPage
 
     public function render(): string
     {
+        global $wpdb;
+
         if (!$this->isEnabled()) {
             return '';
         }
@@ -257,12 +259,55 @@ class AccountPage
             $supporterIds[] = (int) $supporter->id;
         }
 
-        $subscriptions = buyMeCoffeeQuery()
+        $subscriptionRows = buyMeCoffeeQuery()
             ->table('buymecoffee_subscriptions')
+            ->select([
+                buyMeCoffeeQuery()->raw('0 as access_id'),
+                'buymecoffee_subscriptions.id' => 'subscription_id',
+                buyMeCoffeeQuery()->raw("'subscription' as access_type"),
+                'buymecoffee_subscriptions.status',
+                'buymecoffee_subscriptions.current_period_end',
+                'buymecoffee_subscriptions.created_at',
+                'buymecoffee_subscriptions.amount',
+                'buymecoffee_subscriptions.currency',
+                'buymecoffee_subscriptions.interval_type',
+            ])
             ->whereIn('supporter_id', $supporterIds)
+            ->where(function ($subscriptionQuery) {
+                $subscriptionQuery->whereNotNull('stripe_subscription_id')
+                    ->orWhereNull('level_id');
+            })
             ->orderBy('created_at', 'DESC')
             ->limit(20)
             ->get();
+
+        $transactionsTable = $wpdb->prefix . 'buymecoffee_transactions';
+
+        $accessRows = buyMeCoffeeQuery()
+            ->table('buymecoffee_membership_access')
+            ->leftJoin('buymecoffee_transactions', 'buymecoffee_membership_access.transaction_id', '=', 'buymecoffee_transactions.id')
+            ->select([
+                'buymecoffee_membership_access.id' => 'access_id',
+                buyMeCoffeeQuery()->raw('0 as subscription_id'),
+                'buymecoffee_membership_access.access_type',
+                'buymecoffee_membership_access.status',
+                'buymecoffee_membership_access.expires_at' => 'current_period_end',
+                'buymecoffee_membership_access.starts_at' => 'created_at',
+                buyMeCoffeeQuery()->raw("COALESCE({$transactionsTable}.payment_total, 0) as amount"),
+                buyMeCoffeeQuery()->raw("COALESCE({$transactionsTable}.currency, '') as currency"),
+                'buymecoffee_membership_access.access_type' => 'interval_type',
+            ])
+            ->whereIn('buymecoffee_membership_access.supporter_id', $supporterIds)
+            ->whereNull('buymecoffee_membership_access.subscription_id')
+            ->orderBy('buymecoffee_membership_access.created_at', 'DESC')
+            ->limit(20)
+            ->get();
+
+        $subscriptions = array_merge((array) $subscriptionRows, (array) $accessRows);
+        usort($subscriptions, function ($a, $b) {
+            return strtotime($b->created_at ?? '') <=> strtotime($a->created_at ?? '');
+        });
+        $subscriptions = array_slice($subscriptions, 0, 20);
 
         $transactions = buyMeCoffeeQuery()
             ->table('buymecoffee_transactions')

--- a/includes/Classes/Activator.php
+++ b/includes/Classes/Activator.php
@@ -39,8 +39,9 @@ class Activator
     {
         $installedVersion = get_option('buymecoffee_db_version', '1.0');
         if (version_compare($installedVersion, BUYMECOFFEE_DB_VERSION, '<')) {
-            $this->migrate();
-            update_option('buymecoffee_db_version', BUYMECOFFEE_DB_VERSION);
+            if ($this->migrate()) {
+                update_option('buymecoffee_db_version', BUYMECOFFEE_DB_VERSION);
+            }
         }
 
         if (get_option(self::DEFAULT_MEMBERSHIP_LEVEL_SEEDED_OPTION) !== 'yes') {
@@ -53,17 +54,24 @@ class Activator
         $this->createSupportersTable();
         $this->createTransactionTable();
         $this->createSubscriptionsTable();
+        $this->normalizeEmptySubscriptionStripeIds();
         $this->createActivitiesTable();
         $this->createMembershipLevelsTable();
+        $this->createMembershipAccessTable();
         $this->createSupportersMetaTable();
+        $this->backfillMembershipAccessTable();
         $this->seedDefaultMembershipLevel();
+
+        return $this->verifyMigrationState();
     }
 
     private function activateSite()
     {
         $isFreshInstall = $this->isFreshInstall();
 
-        $this->migrate();
+        if (!$this->migrate()) {
+            return;
+        }
 
         if (!get_option(self::INSTALLED_AT_OPTION)) {
             update_option(self::INSTALLED_AT_OPTION, current_time('mysql'), false);
@@ -204,6 +212,23 @@ class Activator
         $this->runSQL($sql, $table_name);
     }
 
+    private function normalizeEmptySubscriptionStripeIds()
+    {
+        global $wpdb;
+
+        $tableName = $wpdb->prefix . 'buymecoffee_subscriptions';
+        $tableLike = $wpdb->esc_like($tableName);
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Migration table existence check.
+        $tableExists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $tableLike));
+        if ($tableExists !== $tableName) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time/manual membership access rows must not collide with the Stripe subscription unique key.
+        $wpdb->query("UPDATE {$tableName} SET stripe_subscription_id = NULL WHERE stripe_subscription_id = ''");
+    }
+
     public function createMembershipLevelsTable()
     {
         global $wpdb;
@@ -214,6 +239,7 @@ class Activator
                 name varchar(255) NOT NULL,
                 description text,
                 price int(11) NOT NULL DEFAULT 0,
+                payment_type varchar(20) NOT NULL DEFAULT 'subscription',
                 interval_type varchar(50) NOT NULL DEFAULT 'month',
                 status varchar(50) NOT NULL DEFAULT 'active',
                 rewards longtext,
@@ -226,6 +252,171 @@ class Activator
         ) $charset_collate;";
 
         $this->runSQL($sql, $table_name);
+    }
+
+    public function createMembershipAccessTable()
+    {
+        global $wpdb;
+        $charset_collate = $wpdb->get_charset_collate();
+        $table_name = $wpdb->prefix . 'buymecoffee_membership_access';
+        $sql = "CREATE TABLE $table_name (
+                id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                supporter_id int(11) NOT NULL,
+                wp_user_id BIGINT(20) UNSIGNED DEFAULT NULL,
+                level_id int(11) NOT NULL,
+                transaction_id int(11) DEFAULT NULL,
+                subscription_id int(11) DEFAULT NULL,
+                access_type varchar(20) NOT NULL DEFAULT 'subscription',
+                status varchar(50) NOT NULL DEFAULT 'incomplete',
+                starts_at timestamp NULL,
+                expires_at timestamp NULL,
+                created_at timestamp NULL,
+                updated_at timestamp NULL,
+                UNIQUE KEY bmc_ma_tx (transaction_id),
+                UNIQUE KEY bmc_ma_sub (subscription_id),
+                KEY bmc_ma_supporter (supporter_id),
+                KEY bmc_ma_wp_user (wp_user_id),
+                KEY bmc_ma_level (level_id),
+                KEY bmc_ma_status (status),
+                KEY bmc_ma_expires (expires_at),
+                KEY bmc_ma_type_status (access_type, status)
+        ) $charset_collate;";
+
+        $this->runSQL($sql, $table_name);
+    }
+
+    private function backfillMembershipAccessTable()
+    {
+        global $wpdb;
+
+        $accessTable = $wpdb->prefix . 'buymecoffee_membership_access';
+        $subscriptionsTable = $wpdb->prefix . 'buymecoffee_subscriptions';
+        $supportersTable = $wpdb->prefix . 'buymecoffee_supporters';
+        $supportersMetaTable = $wpdb->prefix . 'buymecoffee_supporters_meta';
+        $transactionsTable = $wpdb->prefix . 'buymecoffee_transactions';
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Migration table existence checks.
+        $accessExists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($accessTable)));
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Migration table existence checks.
+        $subscriptionsExist = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($subscriptionsTable)));
+        if ($accessExists !== $accessTable || $subscriptionsExist !== $subscriptionsTable) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Normalize older backfills so only recurring access remains linked to subscription rows.
+        $wpdb->query("UPDATE {$accessTable} SET subscription_id = NULL WHERE access_type IN ('one_time', 'manual')");
+
+        $lastId = 0;
+        $batchSize = 500;
+
+        do {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Idempotent migration reads a bounded batch of membership-bearing subscription rows.
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT s.*, sup.wp_user_id
+                 FROM {$subscriptionsTable} s
+                 LEFT JOIN {$supportersTable} sup ON s.supporter_id = sup.id
+                 WHERE s.id > %d AND s.level_id IS NOT NULL AND s.level_id > 0
+                 ORDER BY s.id ASC
+                 LIMIT %d",
+                $lastId,
+                $batchSize
+            ));
+
+            if (empty($rows)) {
+                break;
+            }
+
+            $subscriptionIds = array_map('absint', wp_list_pluck($rows, 'id'));
+            $transactionMap = $this->getFirstTransactionIdsForSubscriptions($subscriptionIds, $transactionsTable);
+
+            foreach ((array) $rows as $row) {
+                $lastId = max($lastId, (int) $row->id);
+                $row->transaction_id = $transactionMap[(int) $row->id] ?? null;
+
+                $this->backfillMembershipAccessRow($row, $accessTable);
+            }
+        } while (count($rows) === $batchSize);
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Access source of truth moved to membership_access; cached level IDs must be recalculated.
+        $wpdb->delete($supportersMetaTable, ['meta_key' => 'active_level_ids']);
+    }
+
+    private function getFirstTransactionIdsForSubscriptions(array $subscriptionIds, $transactionsTable)
+    {
+        global $wpdb;
+
+        $subscriptionIds = array_values(array_filter(array_map('absint', $subscriptionIds)));
+        if (empty($subscriptionIds)) {
+            return [];
+        }
+
+        $ids = implode(',', $subscriptionIds);
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Subscription IDs are absint-cast and imploded into a fixed IN list for migration batching.
+        $rows = $wpdb->get_results("SELECT subscription_id, MIN(id) AS transaction_id FROM {$transactionsTable} WHERE subscription_id IN ({$ids}) GROUP BY subscription_id");
+
+        $map = [];
+        foreach ((array) $rows as $row) {
+            $map[(int) $row->subscription_id] = (int) $row->transaction_id;
+        }
+
+        return $map;
+    }
+
+    private function backfillMembershipAccessRow($row, $accessTable)
+    {
+        global $wpdb;
+
+        $accessType = 'subscription';
+        if (($row->payment_mode ?? '') === 'manual') {
+            $accessType = 'manual';
+        } elseif (($row->interval_type ?? '') === 'one_time') {
+            $accessType = 'one_time';
+        }
+
+        if ($accessType === 'subscription') {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Duplicate guard for idempotent backfill.
+            $existingId = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT id FROM {$accessTable} WHERE subscription_id = %d LIMIT 1",
+                (int) $row->id
+            ));
+        } elseif (!empty($row->transaction_id)) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Duplicate guard for idempotent backfill.
+            $existingId = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT id FROM {$accessTable} WHERE transaction_id = %d LIMIT 1",
+                (int) $row->transaction_id
+            ));
+        } else {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Duplicate guard for idempotent backfill.
+            $existingId = (int) $wpdb->get_var($wpdb->prepare(
+                "SELECT id FROM {$accessTable} WHERE supporter_id = %d AND level_id = %d AND access_type = %s LIMIT 1",
+                (int) $row->supporter_id,
+                (int) $row->level_id,
+                $accessType
+            ));
+        }
+
+        if ($existingId) {
+            return;
+        }
+
+        $expiresAt = null;
+        if ($accessType === 'subscription' && !empty($row->current_period_end) && $row->current_period_end !== '0000-00-00 00:00:00') {
+            $expiresAt = $row->current_period_end;
+        }
+
+        $wpdb->insert($accessTable, [
+            'supporter_id'    => (int) $row->supporter_id,
+            'wp_user_id'      => !empty($row->wp_user_id) ? (int) $row->wp_user_id : null,
+            'level_id'        => (int) $row->level_id,
+            'transaction_id'  => !empty($row->transaction_id) ? (int) $row->transaction_id : null,
+            'subscription_id' => $accessType === 'subscription' ? (int) $row->id : null,
+            'access_type'     => $accessType,
+            'status'          => sanitize_text_field($row->status ?: 'incomplete'),
+            'starts_at'       => !empty($row->created_at) ? $row->created_at : current_time('mysql'),
+            'expires_at'      => $expiresAt,
+            'created_at'      => !empty($row->created_at) ? $row->created_at : current_time('mysql'),
+            'updated_at'      => current_time('mysql'),
+        ]);
     }
 
     private function seedDefaultMembershipLevel()
@@ -259,6 +450,7 @@ class Activator
                 'name'          => 'Supporter',
                 'description'   => 'A sample $10 monthly membership for supporters who want access to premium updates and bonus content.',
                 'price'         => 1000,
+                'payment_type'  => 'subscription',
                 'interval_type' => 'month',
                 'status'        => 'active',
                 'rewards'       => wp_json_encode([
@@ -313,9 +505,75 @@ class Activator
         $this->runSQL($sql, $table_name);
     }
 
+    private function verifyMigrationState()
+    {
+        global $wpdb;
+
+        $requiredTables = [
+            $wpdb->prefix . 'buymecoffee_supporters',
+            $wpdb->prefix . 'buymecoffee_transactions',
+            $wpdb->prefix . 'buymecoffee_subscriptions',
+            $wpdb->prefix . 'buymecoffee_activities',
+            $wpdb->prefix . 'buymecoffee_membership_levels',
+            $wpdb->prefix . 'buymecoffee_membership_access',
+            $wpdb->prefix . 'buymecoffee_supporters_meta',
+        ];
+
+        foreach ($requiredTables as $tableName) {
+            if (!$this->tableExists($tableName)) {
+                return false;
+            }
+        }
+
+        if (!$this->tableHasColumns($wpdb->prefix . 'buymecoffee_membership_levels', ['payment_type'])) {
+            return false;
+        }
+
+        return $this->tableHasColumns($wpdb->prefix . 'buymecoffee_membership_access', [
+            'supporter_id',
+            'wp_user_id',
+            'level_id',
+            'transaction_id',
+            'subscription_id',
+            'access_type',
+            'status',
+            'starts_at',
+            'expires_at',
+        ]);
+    }
+
+    private function tableExists($tableName)
+    {
+        global $wpdb;
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Migration verification table existence check.
+        return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($tableName))) === $tableName;
+    }
+
+    private function tableHasColumns($tableName, array $columns)
+    {
+        global $wpdb;
+
+        if (!$this->tableExists($tableName)) {
+            return false;
+        }
+
+        foreach ($columns as $column) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is plugin-owned; column is prepared below.
+            $exists = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM {$tableName} LIKE %s", $column));
+            if (!$exists) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function runSQL($sql, $tableName)
     {
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
         dbDelta($sql);
+
+        return $this->tableExists($tableName);
     }
 }

--- a/includes/Classes/ActivityLogger.php
+++ b/includes/Classes/ActivityLogger.php
@@ -11,7 +11,7 @@ class ActivityLogger
     /**
      * Core log method. All typed wrappers funnel through here.
      *
-     * @param string $objectType  'payment' | 'subscription' | 'submission' | 'email'
+     * @param string $objectType  'payment' | 'subscription' | 'membership_access' | 'submission' | 'email'
      * @param int    $objectId    Row ID in the corresponding table
      * @param string $event       e.g. 'payment_completed', 'subscription_renewed'
      * @param string $title       Short human-readable one-liner
@@ -79,6 +79,11 @@ class ActivityLogger
     public static function logSubscription(int $subscriptionId, string $event, string $title, array $args = [])
     {
         return self::log('subscription', $subscriptionId, $event, $title, $args);
+    }
+
+    public static function logMembershipAccess(int $accessId, string $event, string $title, array $args = [])
+    {
+        return self::log('membership_access', $accessId, $event, $title, $args);
     }
 
     public static function logSubmission(int $supporterId, string $event, string $title, array $args = [])

--- a/includes/Classes/AdminAjaxHandler.php
+++ b/includes/Classes/AdminAjaxHandler.php
@@ -444,34 +444,39 @@ class AdminAjaxHandler
 
         $batchSize = 500;
 
+        $membershipAccessDeletion = $this->deleteTestMembershipAccessInBatches($batchSize);
         $supporterDeletion = $this->deleteTestSupportersInBatches($batchSize);
         $transactionDeletion = $this->deleteTestRowsInBatches('buymecoffee_transactions', 'payment', $batchSize);
         $subscriptionDeletion = $this->deleteTestRowsInBatches('buymecoffee_subscriptions', 'subscription', $batchSize);
 
+        $deletedMembershipAccess = $membershipAccessDeletion['rows'];
         $deletedSupporters    = $supporterDeletion['rows'];
         $deletedTransactions  = $transactionDeletion['rows'];
         $deletedSubscriptions = $subscriptionDeletion['rows'];
-        $deletedActivities    = $supporterDeletion['activities'] + $transactionDeletion['activities'] + $subscriptionDeletion['activities'];
+        $deletedActivities    = $membershipAccessDeletion['activities'] + $supporterDeletion['activities'] + $transactionDeletion['activities'] + $subscriptionDeletion['activities'];
 
         do_action('buymecoffee_test_data_deleted', [
             'transactions'  => $deletedTransactions,
             'subscriptions' => $deletedSubscriptions,
+            'membership_access' => $deletedMembershipAccess,
             'supporters'    => $deletedSupporters,
             'activities'    => $deletedActivities,
         ]);
 
         wp_send_json_success([
             'message' => sprintf(
-                /* translators: 1: deleted test transaction count, 2: deleted test subscription count, 3: deleted test supporter/customer count, 4: deleted activity log count. */
-                __('Deleted %1$d test transactions, %2$d test subscriptions, %3$d test supporters/customers, and %4$d activity logs.', 'buy-me-coffee'),
+                /* translators: 1: deleted test transaction count, 2: deleted test subscription count, 3: deleted membership access count, 4: deleted test supporter/customer count, 5: deleted activity log count. */
+                __('Deleted %1$d test transactions, %2$d test subscriptions, %3$d membership access records, %4$d test supporters/customers, and %5$d activity logs.', 'buy-me-coffee'),
                 $deletedTransactions,
                 $deletedSubscriptions,
+                $deletedMembershipAccess,
                 $deletedSupporters,
                 $deletedActivities
             ),
             'deleted' => [
                 'transactions'  => $deletedTransactions,
                 'subscriptions' => $deletedSubscriptions,
+                'membership_access' => $deletedMembershipAccess,
                 'supporters'    => $deletedSupporters,
                 'activities'    => $deletedActivities,
             ],
@@ -1267,6 +1272,7 @@ class AdminAjaxHandler
         $allowedTables = [
             'buymecoffee_transactions',
             'buymecoffee_subscriptions',
+            'buymecoffee_membership_access',
             'buymecoffee_supporters',
         ];
 
@@ -1287,7 +1293,7 @@ class AdminAjaxHandler
 
     private function deleteActivityRowsByObjectIds($objectType, $ids)
     {
-        $allowedObjectTypes = ['payment', 'subscription', 'submission', 'email'];
+        $allowedObjectTypes = ['payment', 'subscription', 'membership_access', 'submission', 'email'];
         $objectType = sanitize_key($objectType);
         if (!in_array($objectType, $allowedObjectTypes, true)) {
             return 0;
@@ -1318,6 +1324,27 @@ class AdminAjaxHandler
 
             $deletedActivities += $this->deleteActivityRowsByObjectIds($activityObjectType, $ids);
             $deletedRows += $this->deleteRowsByIds($table, $ids);
+        } while (count($ids) === $batchSize);
+
+        return [
+            'rows'       => $deletedRows,
+            'activities' => $deletedActivities,
+        ];
+    }
+
+    private function deleteTestMembershipAccessInBatches($batchSize)
+    {
+        $deletedRows = 0;
+        $deletedActivities = 0;
+
+        do {
+            $ids = $this->getTestMembershipAccessIds($batchSize);
+            if (empty($ids)) {
+                break;
+            }
+
+            $deletedActivities += $this->deleteActivityRowsByObjectIds('membership_access', $ids);
+            $deletedRows += $this->deleteRowsByIds('buymecoffee_membership_access', $ids);
         } while (count($ids) === $batchSize);
 
         return [
@@ -1364,6 +1391,35 @@ class AdminAjaxHandler
         // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Plugin-owned cleanup query with a fixed allowlisted table name.
         $rows = $wpdb->get_results($wpdb->prepare(
             "SELECT id FROM {$allowedTables[$table]} WHERE payment_mode = %s ORDER BY id ASC LIMIT %d",
+            'test',
+            max(1, absint($limit))
+        ));
+        // phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+        return $this->idsFromRows($rows);
+    }
+
+    private function getTestMembershipAccessIds($limit)
+    {
+        global $wpdb;
+
+        $accessTable = $wpdb->prefix . 'buymecoffee_membership_access';
+        $transactionsTable = $wpdb->prefix . 'buymecoffee_transactions';
+        $subscriptionsTable = $wpdb->prefix . 'buymecoffee_subscriptions';
+        $supportersTable = $wpdb->prefix . 'buymecoffee_supporters';
+
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Plugin-owned cleanup query with fixed table identifiers and bounded LIMIT.
+        $rows = $wpdb->get_results($wpdb->prepare(
+            "SELECT ma.id
+            FROM {$accessTable} ma
+            LEFT JOIN {$transactionsTable} tx ON ma.transaction_id = tx.id
+            LEFT JOIN {$subscriptionsTable} sub ON ma.subscription_id = sub.id
+            LEFT JOIN {$supportersTable} sup ON ma.supporter_id = sup.id
+            WHERE tx.payment_mode = %s OR sub.payment_mode = %s OR sup.payment_mode = %s
+            ORDER BY ma.id ASC
+            LIMIT %d",
+            'test',
+            'test',
             'test',
             max(1, absint($limit))
         ));

--- a/includes/Classes/MembershipAjaxHandler.php
+++ b/includes/Classes/MembershipAjaxHandler.php
@@ -393,26 +393,7 @@ class MembershipAjaxHandler
             ->leftJoin('buymecoffee_membership_levels', 'buymecoffee_membership_access.level_id', '=', 'buymecoffee_membership_levels.id')
             ->leftJoin('buymecoffee_subscriptions', 'buymecoffee_membership_access.subscription_id', '=', 'buymecoffee_subscriptions.id')
             ->whereNotNull('buymecoffee_membership_access.level_id')
-            ->where('buymecoffee_membership_access.level_id', '>', 0)
-            ->where(function ($whereQuery) {
-                $whereQuery->where(function ($activeQuery) {
-                    $activeQuery->where('buymecoffee_membership_access.status', 'active')
-                        ->where(function ($accessQuery) {
-                            $accessQuery->whereIn('buymecoffee_membership_access.access_type', ['one_time', 'manual'])
-                                ->orWhere(function ($periodQuery) {
-                                    $periodQuery->where('buymecoffee_membership_access.access_type', 'subscription')
-                                        ->whereNotNull('buymecoffee_membership_access.expires_at')
-                                        ->where('buymecoffee_membership_access.expires_at', '>', current_time('mysql', true));
-                                });
-                        });
-                })
-                    ->orWhere(function ($cancelledQuery) {
-                        $cancelledQuery->where('buymecoffee_membership_access.status', 'cancelled')
-                            ->where('buymecoffee_membership_access.access_type', 'subscription')
-                            ->whereNotNull('buymecoffee_membership_access.expires_at')
-                            ->where('buymecoffee_membership_access.expires_at', '>', current_time('mysql', true));
-                    });
-            });
+            ->where('buymecoffee_membership_access.level_id', '>', 0);
 
         if ($search !== '') {
             $query->where(function ($whereQuery) use ($search) {

--- a/includes/Classes/MembershipAjaxHandler.php
+++ b/includes/Classes/MembershipAjaxHandler.php
@@ -3,6 +3,7 @@
 namespace BuyMeCoffee\Classes;
 
 use BuyMeCoffee\Models\MembershipLevel;
+use BuyMeCoffee\Models\MembershipAccess;
 use BuyMeCoffee\Controllers\MonetizationController;
 use BuyMeCoffee\Helpers\PaymentHelper;
 
@@ -80,10 +81,13 @@ class MembershipAjaxHandler
         }
 
         $allowedIntervals = ['month', 'year'];
+        $allowedPaymentTypes = ['one_time', 'subscription'];
         $allowedStatuses  = ['active', 'inactive'];
         $allowedAccess    = ['full', 'preview'];
 
         $price        = isset($data['price']) ? absint($data['price']) : 0;
+        $paymentType  = isset($data['payment_type']) && in_array($data['payment_type'], $allowedPaymentTypes, true)
+            ? $data['payment_type'] : 'subscription';
         $intervalType = isset($data['interval_type']) && in_array($data['interval_type'], $allowedIntervals, true)
             ? $data['interval_type'] : 'month';
         $status       = isset($data['status']) && in_array($data['status'], $allowedStatuses, true)
@@ -132,6 +136,7 @@ class MembershipAjaxHandler
             'name'         => $name,
             'description'  => isset($data['description']) ? sanitize_textarea_field($data['description']) : '',
             'price'        => $price,
+            'payment_type' => $paymentType,
             'interval_type' => $intervalType,
             'status'       => $status,
             'rewards'      => wp_json_encode($rewards),
@@ -167,24 +172,37 @@ class MembershipAjaxHandler
 
     private function deleteMembershipLevel($data)
     {
+        global $wpdb;
+
         $id = isset($data['id']) ? absint($data['id']) : 0;
         if (!$id) {
             wp_send_json_error(['message' => __('Invalid level ID.', 'buy-me-coffee')]);
             return;
         }
 
-        // Block deletion if active subscriptions reference this level
-        $activeCount = buyMeCoffeeQuery()
-            ->table('buymecoffee_subscriptions')
-            ->where('level_id', $id)
-            ->where('status', 'active')
-            ->count();
+        $accessTable = $wpdb->prefix . 'buymecoffee_membership_access';
+        $now = current_time('mysql', true);
+
+        // Block deletion if any access record still grants entitlement to this level.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Plugin-owned table with prepared values.
+        $activeCount = (int) $wpdb->get_var($wpdb->prepare(
+            "SELECT COUNT(*)
+             FROM {$accessTable}
+             WHERE level_id = %d
+             AND (
+                (status = 'active' AND (access_type IN ('one_time', 'manual') OR (access_type = 'subscription' AND expires_at IS NOT NULL AND expires_at > %s)))
+                OR (status = 'cancelled' AND access_type = 'subscription' AND expires_at IS NOT NULL AND expires_at > %s)
+             )",
+            $id,
+            $now,
+            $now
+        ));
 
         if ($activeCount > 0) {
             wp_send_json_error([
                 'message' => sprintf(
-                    /* translators: %d: number of active subscribers */
-                    __('Cannot delete: %d active subscriber(s) on this level. Cancel their subscriptions first.', 'buy-me-coffee'),
+                    /* translators: %d: number of active members */
+                    __('Cannot delete: %d active member(s) on this level. Revoke their access first.', 'buy-me-coffee'),
                     (int) $activeCount
                 ),
             ]);
@@ -339,15 +357,22 @@ class MembershipAjaxHandler
 
     private function queryMembershipMembers($search, $limit, $offset)
     {
+        global $wpdb;
+
+        $accessTable = $wpdb->prefix . 'buymecoffee_membership_access';
+        $subscriptionsTable = $wpdb->prefix . 'buymecoffee_subscriptions';
+
         $rows = $this->buildMembershipMembersQuery($search)
             ->select([
-                'buymecoffee_subscriptions.*',
+                'buymecoffee_membership_access.*',
                 'buymecoffee_supporters.supporters_name',
                 'buymecoffee_supporters.supporters_email',
-                'buymecoffee_subscriptions.id'       => 'subscription_id',
-                'buymecoffee_membership_levels.name' => 'level_name',
+                'buymecoffee_membership_access.id'         => 'access_id',
+                'buymecoffee_membership_access.expires_at' => 'current_period_end',
+                'buymecoffee_membership_levels.name'       => 'level_name',
+                buyMeCoffeeQuery()->raw("CASE WHEN {$accessTable}.access_type = 'subscription' THEN {$subscriptionsTable}.interval_type ELSE {$accessTable}.access_type END as interval_type"),
             ])
-            ->orderBy('buymecoffee_subscriptions.created_at', 'DESC')
+            ->orderBy('buymecoffee_membership_access.created_at', 'DESC')
             ->limit(absint($limit))
             ->offset(absint($offset))
             ->get();
@@ -363,17 +388,29 @@ class MembershipAjaxHandler
     private function buildMembershipMembersQuery($search)
     {
         $query = buyMeCoffeeQuery()
-            ->table('buymecoffee_subscriptions')
-            ->leftJoin('buymecoffee_supporters', 'buymecoffee_subscriptions.supporter_id', '=', 'buymecoffee_supporters.id')
-            ->leftJoin('buymecoffee_membership_levels', 'buymecoffee_subscriptions.level_id', '=', 'buymecoffee_membership_levels.id')
-            ->whereNotNull('buymecoffee_subscriptions.level_id')
-            ->where('buymecoffee_subscriptions.level_id', '>', 0)
+            ->table('buymecoffee_membership_access')
+            ->leftJoin('buymecoffee_supporters', 'buymecoffee_membership_access.supporter_id', '=', 'buymecoffee_supporters.id')
+            ->leftJoin('buymecoffee_membership_levels', 'buymecoffee_membership_access.level_id', '=', 'buymecoffee_membership_levels.id')
+            ->leftJoin('buymecoffee_subscriptions', 'buymecoffee_membership_access.subscription_id', '=', 'buymecoffee_subscriptions.id')
+            ->whereNotNull('buymecoffee_membership_access.level_id')
+            ->where('buymecoffee_membership_access.level_id', '>', 0)
             ->where(function ($whereQuery) {
-                $whereQuery->where('buymecoffee_subscriptions.status', 'active')
+                $whereQuery->where(function ($activeQuery) {
+                    $activeQuery->where('buymecoffee_membership_access.status', 'active')
+                        ->where(function ($accessQuery) {
+                            $accessQuery->whereIn('buymecoffee_membership_access.access_type', ['one_time', 'manual'])
+                                ->orWhere(function ($periodQuery) {
+                                    $periodQuery->where('buymecoffee_membership_access.access_type', 'subscription')
+                                        ->whereNotNull('buymecoffee_membership_access.expires_at')
+                                        ->where('buymecoffee_membership_access.expires_at', '>', current_time('mysql', true));
+                                });
+                        });
+                })
                     ->orWhere(function ($cancelledQuery) {
-                        $cancelledQuery->where('buymecoffee_subscriptions.status', 'cancelled')
-                            ->whereNotNull('buymecoffee_subscriptions.current_period_end')
-                            ->where('buymecoffee_subscriptions.current_period_end', '>', current_time('mysql', true));
+                        $cancelledQuery->where('buymecoffee_membership_access.status', 'cancelled')
+                            ->where('buymecoffee_membership_access.access_type', 'subscription')
+                            ->whereNotNull('buymecoffee_membership_access.expires_at')
+                            ->where('buymecoffee_membership_access.expires_at', '>', current_time('mysql', true));
                     });
             });
 
@@ -414,8 +451,8 @@ class MembershipAjaxHandler
             return;
         }
 
-        $subscriptionId = $this->grantInviteSubscription($userId, $supporterId, $level);
-        if (!$subscriptionId) {
+        $accessId = $this->grantInviteSubscription($userId, $supporterId, $level);
+        if (!$accessId) {
             wp_send_json_error(['message' => __('This member already has access to that level.', 'buy-me-coffee')]);
             return;
         }
@@ -518,7 +555,7 @@ class MembershipAjaxHandler
         }
 
         $existing = buyMeCoffeeQuery()
-            ->table('buymecoffee_subscriptions')
+            ->table('buymecoffee_membership_access')
             ->whereIn('supporter_id', $supporterIds)
             ->where('level_id', (int) $level->id)
             ->where('status', 'active')
@@ -528,31 +565,13 @@ class MembershipAjaxHandler
             return 0;
         }
 
-        $subscriptionId = buyMeCoffeeQuery()->table('buymecoffee_subscriptions')->insert([
-            'supporter_id'            => (int) $supporterId,
-            'stripe_subscription_id'  => null,
-            'stripe_customer_id'      => null,
-            'interval_type'           => sanitize_text_field($level->interval_type ?: 'month'),
-            'amount'                  => 0,
-            'currency'                => strtolower(PaymentHelper::getCurrency()),
-            'status'                  => 'active',
-            'payment_mode'            => 'manual',
-            'current_period_end'      => null,
-            'cancelled_at'            => null,
-            'level_id'                => (int) $level->id,
-            'created_at'              => current_time('mysql'),
-            'updated_at'              => current_time('mysql'),
-        ]);
+        $accessId = (new MembershipAccess())->grantManualAccess((int) $supporterId, (int) $userId, (int) $level->id);
 
-        if ($subscriptionId && function_exists('buymecoffee_delete_supporter_meta')) {
+        if ($accessId && function_exists('buymecoffee_delete_supporter_meta')) {
             buymecoffee_delete_supporter_meta((int) $supporterIds[0], 'active_level_ids');
         }
 
-        if ($subscriptionId) {
-            do_action('buymecoffee_subscription_activated', (int) $subscriptionId);
-        }
-
-        return (int) $subscriptionId;
+        return (int) $accessId;
     }
 
     private function sanitizeData($data)

--- a/includes/Classes/UserManager.php
+++ b/includes/Classes/UserManager.php
@@ -2,6 +2,8 @@
 
 namespace BuyMeCoffee\Classes;
 
+use BuyMeCoffee\Models\MembershipAccess;
+
 if (!defined('ABSPATH')) exit;
 
 class UserManager
@@ -11,6 +13,7 @@ class UserManager
         add_action('buymecoffee_subscription_activated', [$this, 'handleSubscriptionActivated']);
         add_action('buymecoffee_subscription_cancelled', [$this, 'handleSubscriptionCancelled']);
         add_action('buymecoffee_subscription_status_changed', [$this, 'handleSubscriptionStatusChanged'], 10, 3);
+        add_action('buymecoffee_membership_access_activated', [$this, 'handleMembershipAccessActivated']);
     }
 
     private function isEnabled(): bool
@@ -21,16 +24,22 @@ class UserManager
 
     public function handleSubscriptionActivated($subscriptionId)
     {
-        if (!$this->isEnabled()) {
-            return;
-        }
-
         $subscription = buyMeCoffeeQuery()
             ->table('buymecoffee_subscriptions')
             ->where('id', (int) $subscriptionId)
             ->first();
 
         if (!$subscription) {
+            return;
+        }
+
+        $isMembershipAccess = !empty($subscription->level_id);
+        if ($isMembershipAccess) {
+            (new MembershipAccess())->upsertFromSubscription((int) $subscription->id);
+            return;
+        }
+
+        if (!$isMembershipAccess && !$this->isEnabled()) {
             return;
         }
 
@@ -84,12 +93,63 @@ class UserManager
 
     public function handleSubscriptionCancelled($subscriptionId)
     {
+        (new MembershipAccess())->upsertFromSubscription((int) $subscriptionId);
         $this->syncBySubscriptionId((int) $subscriptionId);
     }
 
     public function handleSubscriptionStatusChanged($subscriptionId, $oldStatus, $newStatus)
     {
+        (new MembershipAccess())->upsertFromSubscription((int) $subscriptionId);
         $this->syncBySubscriptionId((int) $subscriptionId);
+    }
+
+    public function handleMembershipAccessActivated($accessId)
+    {
+        $access = (new MembershipAccess())->find((int) $accessId);
+        if (!$access) {
+            return;
+        }
+
+        $supporter = buyMeCoffeeQuery()
+            ->table('buymecoffee_supporters')
+            ->where('id', (int) $access->supporter_id)
+            ->first();
+
+        if (!$supporter || empty($supporter->supporters_email)) {
+            return;
+        }
+
+        if (!empty($supporter->wp_user_id)) {
+            (new MembershipAccess())->updateData((int) $access->id, [
+                'wp_user_id' => (int) $supporter->wp_user_id,
+                'updated_at' => current_time('mysql'),
+            ]);
+            $this->syncSubscriptionAccessMeta((int) $supporter->wp_user_id);
+            return;
+        }
+
+        $userData = $this->getOrCreateUser(
+            $supporter->supporters_email,
+            $supporter->supporters_name ?? ''
+        );
+
+        if (empty($userData['user_id'])) {
+            return;
+        }
+
+        $userId = (int) $userData['user_id'];
+
+        $this->linkUserToSupporter((int) $supporter->id, $userId);
+        (new MembershipAccess())->updateData((int) $access->id, [
+            'wp_user_id' => $userId,
+            'updated_at' => current_time('mysql'),
+        ]);
+        $this->syncSubscriptionAccessMeta($userId);
+
+        if (!empty($userData['created']) && !is_user_logged_in() && $this->isBrowserRequest()) {
+            wp_set_current_user($userId);
+            wp_set_auth_cookie($userId, true);
+        }
     }
 
     private function syncBySubscriptionId(int $subscriptionId): void

--- a/includes/Controllers/MonetizationController.php
+++ b/includes/Controllers/MonetizationController.php
@@ -80,7 +80,7 @@ class MonetizationController
 
     private function renderPaywallCta($postId)
     {
-        $allLevels   = self::getActiveLevels();
+        $allLevels   = (new MembershipLevel())->getForAdmin();
         $levels      = $this->filterLevelsForPost($postId, $allLevels);
         $settings    = self::getGlobalSettings();
         $membershipPaused = !self::isMembershipActive();
@@ -156,7 +156,7 @@ class MonetizationController
         }
 
         $args['bmc_level']       = $level;
-        $args['force_recurring'] = true;
+        $args['force_recurring'] = empty($level->payment_type) || $level->payment_type === 'subscription';
 
         return $args;
     }

--- a/includes/Controllers/SubmissionHandler.php
+++ b/includes/Controllers/SubmissionHandler.php
@@ -234,22 +234,36 @@ class SubmissionHandler
             ], 400);
         }
 
+        $supporterEmail = sanitize_email(ArrayHelper::get($formData, 'wpm-supporter-email', ''));
+        if (!$supporterEmail || !is_email($supporterEmail)) {
+            wp_send_json_error([
+                'message' => __('A valid email address is required for membership access.', 'buy-me-coffee')
+            ], 400);
+        }
+        $formData['wpm-supporter-email'] = $supporterEmail;
+
         $interval = isset($level->interval_type) ? sanitize_text_field($level->interval_type) : 'month';
         if (!in_array($interval, ['month', 'year'], true)) {
             $interval = 'month';
         }
 
+        $paymentType = isset($level->payment_type) ? sanitize_key($level->payment_type) : 'subscription';
+        if (!in_array($paymentType, ['one_time', 'subscription'], true)) {
+            $paymentType = 'subscription';
+        }
+
         $paymentTotal = $levelPrice;
         $quantity = 1;
-        $isRecurring = 'yes';
+        $isRecurring = $paymentType === 'subscription' ? 'yes' : 'no';
         $recurringInterval = $interval;
 
         $formData['bmc_level_id'] = $levelId;
+        $formData['bmc_level_payment_type'] = $paymentType;
         $formData['buymecoffee_amount'] = (string) ($levelPrice / 100);
         $formData['buymecoffee_quantity'] = '1';
         $formData['payment_total'] = $levelPrice;
         $formData['currency'] = $currency;
-        $formData['is_recurring'] = 'yes';
+        $formData['is_recurring'] = $isRecurring;
         $formData['recurring_interval'] = $interval;
 
         return $level;

--- a/includes/Helpers/PaymentHelper.php
+++ b/includes/Helpers/PaymentHelper.php
@@ -6,6 +6,7 @@ use BuyMeCoffee\Builder\Methods\Stripe\API;
 use BuyMeCoffee\Builder\Methods\Stripe\StripeSettings;
 use BuyMeCoffee\Controllers\SubmissionHandler;
 use BuyMeCoffee\Models\Buttons;
+use BuyMeCoffee\Models\MembershipAccess;
 use BuyMeCoffee\Models\Supporters;
 use BuyMeCoffee\Helpers\ArrayHelper as Arr;
 use BuyMeCoffee\Models\Subscriptions;
@@ -34,7 +35,7 @@ class PaymentHelper
         $response = $api->makeRequest($path, [], (new StripeSettings())->getKeys('secret'));
 
         if (!$response || is_wp_error($response)) {
-            return;
+            return new \WP_Error('stripe_payment_lookup_failed', __('Unable to verify the Stripe payment.', 'buy-me-coffee'));
         }
 
         $orderHash = Arr::get($response, 'metadata.ref_id');
@@ -44,17 +45,18 @@ class PaymentHelper
         $paymentHelper = new PaymentHelper();
         $order =  $paymentHelper->getByHash($orderHash);
         if (!$order || empty($order->transaction)) {
-            return;
+            return new \WP_Error('stripe_payment_order_missing', __('Unable to match this payment to an order.', 'buy-me-coffee'));
         }
 
         // For subscriptions the PI amount may not yet be reflected in amount_received
         // at the moment the confirmation fires, so allow a zero amount_received to pass
         // (the status check below still gates on 'succeeded').
         if ($amount > 0 && intval($order->payment_total) !== $amount) {
-            return;
+            return new \WP_Error('stripe_payment_amount_mismatch', __('Payment amount does not match the order.', 'buy-me-coffee'));
         }
 
-        $status = Arr::get($response, 'status') === 'succeeded' ? 'paid' : 'pending';
+        $stripeStatus = sanitize_text_field(Arr::get($response, 'status', ''));
+        $status = $stripeStatus === 'succeeded' ? 'paid' : 'pending';
         $card = Arr::get($response, 'charges.data.0.payment_method_details.card');
         $last4 = Arr::get($card, 'last4');
         $cardBand = Arr::get($card, 'brand');
@@ -91,7 +93,69 @@ class PaymentHelper
             do_action('buymecoffee_subscription_activated', (int) $order->transaction->subscription_id);
         }
 
+        $membershipAccess = $this->getMembershipAccessByTransaction((int) $order->transaction->id);
+        $membershipAccessId = $membershipAccess ? (int) $membershipAccess->id : 0;
+
+        if ($status === 'paid' && empty($order->transaction->subscription_id)) {
+            $membershipAccessId = (new MembershipAccess())->activateByTransaction((int) $order->transaction->id);
+            $membershipAccess = $membershipAccessId ? (new MembershipAccess())->find($membershipAccessId) : $membershipAccess;
+        }
+
         do_action('buymecoffee_payment_status_updated', $order->transaction->id, $status);
+
+        $subscription = null;
+        if (!empty($order->transaction->subscription_id)) {
+            $subscription = buyMeCoffeeQuery()
+                ->table('buymecoffee_subscriptions')
+                ->where('id', (int) $order->transaction->subscription_id)
+                ->first();
+            $membershipAccess = $this->getMembershipAccessBySubscription((int) $order->transaction->subscription_id) ?: $membershipAccess;
+            if ($membershipAccess && !$membershipAccessId) {
+                $membershipAccessId = (int) $membershipAccess->id;
+            }
+        }
+
+        $isMembership = !empty($membershipAccess) || !empty($subscription->level_id);
+        $accessActive = $status === 'paid' && (
+            !$isMembership
+            || ($membershipAccess && Subscriptions::hasAccessValidity($membershipAccess))
+        );
+
+        return [
+            'payment_status'           => $status,
+            'stripe_status'            => $stripeStatus,
+            'transaction_id'           => (int) $order->transaction->id,
+            'subscription_id'          => !empty($order->transaction->subscription_id) ? (int) $order->transaction->subscription_id : 0,
+            'is_subscription'          => !empty($order->transaction->subscription_id),
+            'is_membership'            => $isMembership,
+            'membership_access_id'     => $membershipAccessId,
+            'membership_access_status' => !empty($membershipAccess->status) ? sanitize_text_field($membershipAccess->status) : '',
+            'access_active'            => (bool) $accessActive,
+        ];
+    }
+
+    private function getMembershipAccessByTransaction(int $transactionId)
+    {
+        if (!$transactionId) {
+            return null;
+        }
+
+        return buyMeCoffeeQuery()
+            ->table('buymecoffee_membership_access')
+            ->where('transaction_id', $transactionId)
+            ->first();
+    }
+
+    private function getMembershipAccessBySubscription(int $subscriptionId)
+    {
+        if (!$subscriptionId) {
+            return null;
+        }
+
+        return buyMeCoffeeQuery()
+            ->table('buymecoffee_membership_access')
+            ->where('subscription_id', $subscriptionId)
+            ->first();
     }
 
     private function resolveStripeSubscriptionPeriodEnd(int $localSubscriptionId): ?string

--- a/includes/Models/MembershipAccess.php
+++ b/includes/Models/MembershipAccess.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace BuyMeCoffee\Models;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+class MembershipAccess extends Model
+{
+    protected $table = 'buymecoffee_membership_access';
+
+    public function upsertFromSubscription($subscriptionId, $fireAction = true)
+    {
+        $subscriptionId = absint($subscriptionId);
+        if (!$subscriptionId) {
+            return 0;
+        }
+
+        $subscription = buyMeCoffeeQuery()
+            ->table('buymecoffee_subscriptions')
+            ->where('id', $subscriptionId)
+            ->first();
+
+        if (!$subscription || empty($subscription->level_id)) {
+            return 0;
+        }
+
+        $supporter = buyMeCoffeeQuery()
+            ->table('buymecoffee_supporters')
+            ->where('id', (int) $subscription->supporter_id)
+            ->first();
+
+        $transaction = buyMeCoffeeQuery()
+            ->table('buymecoffee_transactions')
+            ->where('subscription_id', $subscriptionId)
+            ->orderBy('id', 'ASC')
+            ->first();
+
+        $accessType = 'subscription';
+        if (($subscription->payment_mode ?? '') === 'manual') {
+            $accessType = 'manual';
+        } elseif (($subscription->interval_type ?? '') === 'one_time') {
+            $accessType = 'one_time';
+        }
+
+        $expiresAt = null;
+        if ($accessType === 'subscription' && !empty($subscription->current_period_end) && $subscription->current_period_end !== '0000-00-00 00:00:00') {
+            $expiresAt = $subscription->current_period_end;
+        }
+
+        $identity = ['subscription_id' => $subscriptionId];
+        $storedSubscriptionId = $subscriptionId;
+
+        if ($accessType !== 'subscription') {
+            $storedSubscriptionId = null;
+            if ($transaction) {
+                $identity = ['transaction_id' => (int) $transaction->id];
+            } else {
+                $identity = [
+                    'supporter_id' => (int) $subscription->supporter_id,
+                    'level_id'     => (int) $subscription->level_id,
+                    'access_type'  => $accessType,
+                ];
+            }
+        }
+
+        return $this->upsert([
+            'supporter_id'    => (int) $subscription->supporter_id,
+            'wp_user_id'      => !empty($supporter->wp_user_id) ? (int) $supporter->wp_user_id : null,
+            'level_id'        => (int) $subscription->level_id,
+            'transaction_id'  => $transaction ? (int) $transaction->id : null,
+            'subscription_id' => $storedSubscriptionId,
+            'access_type'     => $accessType,
+            'status'          => sanitize_text_field($subscription->status ?: 'incomplete'),
+            'starts_at'       => !empty($subscription->created_at) ? $subscription->created_at : current_time('mysql'),
+            'expires_at'      => $expiresAt,
+        ], $identity, $fireAction);
+    }
+
+    public function createPendingForTransaction($transactionId, $supporterId, $levelId, $accessType = 'one_time')
+    {
+        $transactionId = absint($transactionId);
+        $supporterId = absint($supporterId);
+        $levelId = absint($levelId);
+
+        if (!$transactionId || !$supporterId || !$levelId) {
+            return 0;
+        }
+
+        $supporter = buyMeCoffeeQuery()
+            ->table('buymecoffee_supporters')
+            ->where('id', $supporterId)
+            ->first();
+
+        return $this->upsert([
+            'supporter_id'    => $supporterId,
+            'wp_user_id'      => !empty($supporter->wp_user_id) ? (int) $supporter->wp_user_id : null,
+            'level_id'        => $levelId,
+            'transaction_id'  => $transactionId,
+            'subscription_id' => null,
+            'access_type'     => sanitize_key($accessType) ?: 'one_time',
+            'status'          => 'incomplete',
+            'starts_at'       => current_time('mysql'),
+            'expires_at'      => null,
+        ], ['transaction_id' => $transactionId], false);
+    }
+
+    public function grantManualAccess($supporterId, $wpUserId, $levelId)
+    {
+        $supporterId = absint($supporterId);
+        $wpUserId = absint($wpUserId);
+        $levelId = absint($levelId);
+
+        if (!$supporterId || !$levelId) {
+            return 0;
+        }
+
+        return $this->upsert([
+            'supporter_id'    => $supporterId,
+            'wp_user_id'      => $wpUserId ?: null,
+            'level_id'        => $levelId,
+            'transaction_id'  => null,
+            'subscription_id' => null,
+            'access_type'     => 'manual',
+            'status'          => 'active',
+            'starts_at'       => current_time('mysql'),
+            'expires_at'      => null,
+        ], [
+            'supporter_id' => $supporterId,
+            'level_id'     => $levelId,
+            'access_type'  => 'manual',
+        ], true);
+    }
+
+    public function activateByTransaction($transactionId)
+    {
+        $transactionId = absint($transactionId);
+        if (!$transactionId) {
+            return 0;
+        }
+
+        $access = $this->getQuery()
+            ->where('transaction_id', $transactionId)
+            ->first();
+
+        if (!$access) {
+            return 0;
+        }
+
+        $this->updateData((int) $access->id, [
+            'status'     => 'active',
+            'updated_at' => current_time('mysql'),
+        ]);
+
+        $this->invalidateSupporterAccessCache((int) $access->supporter_id);
+        do_action('buymecoffee_membership_access_activated', (int) $access->id);
+
+        return (int) $access->id;
+    }
+
+    public function updateData($id, $data)
+    {
+        global $wpdb;
+
+        return $wpdb->update(
+            $wpdb->prefix . $this->table,
+            $data,
+            ['id' => absint($id)]
+        );
+    }
+
+    public function getActiveLevelIdsForUser($userId)
+    {
+        $userId = absint($userId);
+        if (!$userId) {
+            return [];
+        }
+
+        $now = current_time('mysql', true);
+        $supporterIds = buymecoffee_get_supporter_ids_for_user($userId);
+        if (empty($supporterIds)) {
+            return [];
+        }
+
+        $rows = $this->getQuery()
+            ->select(['level_id'])
+            ->whereIn('supporter_id', $supporterIds)
+            ->where(function ($whereQuery) use ($now) {
+                $whereQuery->where(function ($activeQuery) use ($now) {
+                    $activeQuery->where('status', 'active')
+                        ->where(function ($accessQuery) use ($now) {
+                            $accessQuery->whereIn('access_type', ['one_time', 'manual'])
+                                ->orWhere(function ($periodQuery) use ($now) {
+                                    $periodQuery->where('access_type', 'subscription')
+                                        ->whereNotNull('expires_at')
+                                        ->where('expires_at', '>', $now);
+                                });
+                        });
+                })
+                    ->orWhere(function ($cancelledQuery) use ($now) {
+                        $cancelledQuery->where('status', 'cancelled')
+                            ->where('access_type', 'subscription')
+                            ->whereNotNull('expires_at')
+                            ->where('expires_at', '>', $now);
+                    });
+            })
+            ->get();
+
+        $levelIds = [];
+        foreach ($rows as $row) {
+            if (!empty($row->level_id)) {
+                $levelIds[] = (int) $row->level_id;
+            }
+        }
+
+        return array_values(array_unique($levelIds));
+    }
+
+    private function upsert(array $data, array $identity, $fireAction)
+    {
+        global $wpdb;
+
+        $existing = $this->findExisting($identity);
+        $now = current_time('mysql');
+
+        $row = [
+            'supporter_id'    => (int) $data['supporter_id'],
+            'wp_user_id'      => !empty($data['wp_user_id']) ? (int) $data['wp_user_id'] : null,
+            'level_id'        => (int) $data['level_id'],
+            'transaction_id'  => !empty($data['transaction_id']) ? (int) $data['transaction_id'] : null,
+            'subscription_id' => !empty($data['subscription_id']) ? (int) $data['subscription_id'] : null,
+            'access_type'     => sanitize_key($data['access_type'] ?? 'subscription'),
+            'status'          => sanitize_text_field($data['status'] ?? 'incomplete'),
+            'starts_at'       => !empty($data['starts_at']) ? sanitize_text_field($data['starts_at']) : $now,
+            'expires_at'      => !empty($data['expires_at']) ? sanitize_text_field($data['expires_at']) : null,
+            'updated_at'      => $now,
+        ];
+
+        if ($existing) {
+            $this->updateData((int) $existing->id, $row);
+            $accessId = (int) $existing->id;
+        } else {
+            $row['created_at'] = $now;
+            $inserted = $wpdb->insert($wpdb->prefix . $this->table, $row);
+            $accessId = $inserted ? (int) $wpdb->insert_id : 0;
+        }
+
+        if ($accessId) {
+            $this->invalidateSupporterAccessCache((int) $row['supporter_id']);
+            if ($fireAction && $this->rowGrantsAccess((object) $row)) {
+                do_action('buymecoffee_membership_access_activated', $accessId);
+            }
+        }
+
+        return $accessId;
+    }
+
+    private function findExisting(array $identity)
+    {
+        $query = $this->getQuery();
+        foreach ($identity as $key => $value) {
+            if ($value === null || $value === '') {
+                $query->whereNull($key);
+            } else {
+                $query->where($key, $value);
+            }
+        }
+
+        return $query->first();
+    }
+
+    private function rowGrantsAccess($row)
+    {
+        if ($row->status !== 'active' && $row->status !== 'cancelled') {
+            return false;
+        }
+
+        if ($row->status === 'active' && in_array($row->access_type, ['one_time', 'manual'], true)) {
+            return true;
+        }
+
+        return $row->access_type === 'subscription'
+            && !empty($row->expires_at)
+            && strtotime($row->expires_at) > time();
+    }
+
+    private function invalidateSupporterAccessCache($supporterId)
+    {
+        if ($supporterId && function_exists('buymecoffee_delete_supporter_meta')) {
+            buymecoffee_delete_supporter_meta((int) $supporterId, 'active_level_ids');
+        }
+    }
+}

--- a/includes/Models/MembershipLevel.php
+++ b/includes/Models/MembershipLevel.php
@@ -8,6 +8,11 @@ class MembershipLevel extends Model
 {
     protected $table = 'buymecoffee_membership_levels';
 
+    public function find($id)
+    {
+        return $this->decodeJsonFields(parent::find($id));
+    }
+
     public function getActive()
     {
         $rows = $this->getQuery()
@@ -58,6 +63,7 @@ class MembershipLevel extends Model
         if (is_object($row)) {
             $row->rewards      = !empty($row->rewards) ? json_decode($row->rewards, true) : [];
             $row->access_rules = !empty($row->access_rules) ? json_decode($row->access_rules, true) : [];
+            $row->payment_type = !empty($row->payment_type) ? sanitize_key($row->payment_type) : 'subscription';
         }
         return $row;
     }

--- a/includes/Models/Subscriptions.php
+++ b/includes/Models/Subscriptions.php
@@ -16,8 +16,9 @@ class Subscriptions extends Model
     /**
      * Check if a subscription still grants content access.
      *
-     * Returns true when the subscription is active, or when it was cancelled
-     * but the already-paid billing period (current_period_end) hasn't expired yet.
+     * Returns true when one-time/manual access is active, when recurring access
+     * is active and still inside current_period_end, or when it was cancelled
+     * but the already-paid billing period hasn't expired yet.
      *
      * @param object $subscription Subscription row object.
      * @return bool
@@ -28,14 +29,28 @@ class Subscriptions extends Model
             return false;
         }
 
+        $accessType = $subscription->access_type ?? '';
         if ($subscription->status === 'active') {
-            return true;
+            if (in_array($accessType, ['one_time', 'manual'], true)
+                || ($subscription->interval_type ?? '') === 'one_time'
+                || ($subscription->interval_type ?? '') === 'manual'
+                || ($subscription->payment_mode ?? '') === 'manual') {
+                return true;
+            }
+
+            $expiresAt = $subscription->expires_at ?? $subscription->current_period_end ?? '';
+
+            return !empty($expiresAt)
+                && $expiresAt !== '0000-00-00 00:00:00'
+                && strtotime($expiresAt) > time();
         }
 
+        $expiresAt = $subscription->expires_at ?? $subscription->current_period_end ?? '';
+
         return $subscription->status === 'cancelled'
-            && !empty($subscription->current_period_end)
-            && $subscription->current_period_end !== '0000-00-00 00:00:00'
-            && strtotime($subscription->current_period_end) > time();
+            && !empty($expiresAt)
+            && $expiresAt !== '0000-00-00 00:00:00'
+            && strtotime($expiresAt) > time();
     }
 
     public function findByStripeId($stripeSubscriptionId)
@@ -95,7 +110,7 @@ class Subscriptions extends Model
         $stats = $this->getQuery()
             ->select(
                 $this->raw('COUNT(*) as active_count'),
-                $this->raw("COALESCE(SUM(CASE WHEN interval_type = 'year' THEN ROUND(amount / 12) ELSE amount END), 0) as mrr")
+                $this->raw("COALESCE(SUM(CASE WHEN interval_type = 'one_time' THEN 0 WHEN interval_type = 'year' THEN ROUND(amount / 12) ELSE amount END), 0) as mrr")
             )
             ->where('status', 'active')
             ->first();
@@ -124,13 +139,13 @@ class Subscriptions extends Model
         $recent = [];
         foreach ($recent_rows as $row) {
             $amountFormatted = \BuyMeCoffee\Helpers\PaymentHelper::getFormattedAmount((int) $row->amount, $row->currency ?: 'USD');
-            $interval = ($row->interval_type === 'year') ? '/yr' : '/mo';
+            $interval = $row->interval_type === 'one_time' ? '' : (($row->interval_type === 'year') ? '/yr' : '/mo');
             $recent[] = [
                 'id'     => $row->id,
                 'name'   => $row->supporters_name ?: 'Anonymous',
                 'email'  => $row->supporters_email ?: '',
                 'amount' => $amountFormatted . $interval,
-                'plan'   => ucfirst($row->interval_type ?? 'month') . 'ly',
+                'plan'   => $row->interval_type === 'one_time' ? __('One-time', 'buy-me-coffee') : ucfirst($row->interval_type ?? 'month') . 'ly',
                 'status' => $row->status,
             ];
         }

--- a/includes/Models/Supporters.php
+++ b/includes/Models/Supporters.php
@@ -257,6 +257,28 @@ class Supporters extends Model
                 ->first();
         }
 
+        $supporter->membership_access = buyMeCoffeeQuery()
+            ->table('buymecoffee_membership_access')
+            ->leftJoin('buymecoffee_membership_levels', 'buymecoffee_membership_access.level_id', '=', 'buymecoffee_membership_levels.id')
+            ->leftJoin('buymecoffee_subscriptions', 'buymecoffee_membership_access.subscription_id', '=', 'buymecoffee_subscriptions.id')
+            ->leftJoin('buymecoffee_transactions', 'buymecoffee_membership_access.transaction_id', '=', 'buymecoffee_transactions.id')
+            ->select([
+                'buymecoffee_membership_access.*',
+                'buymecoffee_membership_levels.name'       => 'level_name',
+                'buymecoffee_subscriptions.interval_type'  => 'billing_interval',
+                'buymecoffee_subscriptions.amount'         => 'subscription_amount',
+                'buymecoffee_subscriptions.currency'       => 'subscription_currency',
+                'buymecoffee_transactions.payment_total'   => 'transaction_amount',
+                'buymecoffee_transactions.currency'        => 'transaction_currency',
+                'buymecoffee_transactions.charge_id'       => 'transaction_charge_id',
+                'buymecoffee_transactions.payment_method'  => 'transaction_payment_method',
+                'buymecoffee_transactions.status'          => 'transaction_status',
+            ])
+            ->where('buymecoffee_membership_access.supporter_id', (int) $supporter->id)
+            ->orderBy('buymecoffee_membership_access.created_at', 'DESC')
+            ->limit(50)
+            ->get();
+
         return $supporter;
     }
 

--- a/includes/global_functions.php
+++ b/includes/global_functions.php
@@ -124,10 +124,11 @@ if (!function_exists('buymecoffee_subscription_access_where')) {
     /**
      * Build the WHERE clause for subscriptions that grant content access.
      *
-     * A subscription grants access if:
-     *   - status is 'active', OR
-     *   - status is 'cancelled' but current_period_end is still in the future
-     *     (the subscriber already paid for this billing cycle)
+     * A membership grants access if:
+     *   - one-time/manual access is active, OR
+     *   - recurring access is active and current_period_end is still in the future, OR
+     *   - recurring access is cancelled but current_period_end is still in the future
+     *     (the member already paid for this billing cycle)
      *
      * @param string $table  Fully-qualified subscriptions table name.
      * @return string SQL WHERE fragment (without leading WHERE/AND).
@@ -135,7 +136,21 @@ if (!function_exists('buymecoffee_subscription_access_where')) {
     function buymecoffee_subscription_access_where($table)
     {
         $now = current_time('mysql', true); // UTC
-        return "({$table}.status = 'active' OR ({$table}.status = 'cancelled' AND {$table}.current_period_end IS NOT NULL AND {$table}.current_period_end > '{$now}'))";
+        return "(({$table}.status = 'active' AND ({$table}.interval_type = 'one_time' OR {$table}.payment_mode = 'manual' OR ({$table}.current_period_end IS NOT NULL AND {$table}.current_period_end > '{$now}'))) OR ({$table}.status = 'cancelled' AND {$table}.current_period_end IS NOT NULL AND {$table}.current_period_end > '{$now}'))";
+    }
+}
+
+if (!function_exists('buymecoffee_membership_access_where')) {
+    /**
+     * Build the WHERE clause for membership access rows that grant content access.
+     *
+     * @param string $table Fully-qualified membership access table name.
+     * @return string SQL WHERE fragment (without leading WHERE/AND).
+     */
+    function buymecoffee_membership_access_where($table)
+    {
+        $now = current_time('mysql', true);
+        return "(({$table}.status = 'active' AND ({$table}.access_type IN ('one_time', 'manual') OR ({$table}.access_type = 'subscription' AND {$table}.expires_at IS NOT NULL AND {$table}.expires_at > '{$now}'))) OR ({$table}.status = 'cancelled' AND {$table}.access_type = 'subscription' AND {$table}.expires_at IS NOT NULL AND {$table}.expires_at > '{$now}'))";
     }
 }
 
@@ -172,29 +187,7 @@ if (!function_exists('buymecoffee_user_get_active_level_ids')) {
             }
         }
 
-        $rows = buyMeCoffeeQuery()
-            ->table('buymecoffee_subscriptions')
-            ->select(['level_id'])
-            ->whereIn('supporter_id', $supporterIds)
-            ->whereNotNull('level_id')
-            ->where(function ($whereQuery) {
-                $whereQuery->where('status', 'active')
-                    ->orWhere(function ($cancelledQuery) {
-                        $cancelledQuery->where('status', 'cancelled')
-                            ->whereNotNull('current_period_end')
-                            ->where('current_period_end', '>', current_time('mysql', true));
-                    });
-            })
-            ->get();
-
-        $levelIds = [];
-        foreach ($rows as $row) {
-            if (!empty($row->level_id)) {
-                $levelIds[] = (int) $row->level_id;
-            }
-        }
-
-        $levelIds = array_unique($levelIds);
+        $levelIds = (new \BuyMeCoffee\Models\MembershipAccess())->getActiveLevelIdsForUser($userId);
         buymecoffee_update_supporter_meta($primarySupporterId, 'active_level_ids', $levelIds);
 
         return $levelIds;

--- a/includes/views/templates/SubscriberAccount.php
+++ b/includes/views/templates/SubscriberAccount.php
@@ -32,9 +32,9 @@ $statusLabels = [
         </a>
     </div>
 
-    <!-- Subscriptions -->
+    <!-- Memberships and subscriptions -->
     <div class="bmc-account-card">
-        <h3 class="bmc-account-card__title"><?php esc_html_e('Your Subscriptions', 'buy-me-coffee'); ?></h3>
+        <h3 class="bmc-account-card__title"><?php esc_html_e('Your Memberships & Subscriptions', 'buy-me-coffee'); ?></h3>
 
         <?php if (!empty($subscriptions)) : ?>
             <div class="bmc-account-table-wrap">
@@ -52,7 +52,13 @@ $statusLabels = [
                     <tbody>
                         <?php foreach ($subscriptions as $sub) :
                             $amount = $sub->amount ? html_entity_decode(PaymentHelper::getFormattedAmount($sub->amount, $sub->currency), ENT_QUOTES | ENT_HTML5, 'UTF-8') : '--';
-                            $interval = $sub->interval_type === 'one_time' ? __('One-time', 'buy-me-coffee') : (($sub->interval_type === 'year') ? __('Yearly', 'buy-me-coffee') : __('Monthly', 'buy-me-coffee'));
+                            if ($sub->interval_type === 'one_time') {
+                                $interval = __('One-time', 'buy-me-coffee');
+                            } elseif ($sub->interval_type === 'manual') {
+                                $interval = __('Manual', 'buy-me-coffee');
+                            } else {
+                                $interval = $sub->interval_type === 'year' ? __('Yearly', 'buy-me-coffee') : __('Monthly', 'buy-me-coffee');
+                            }
                             $status = isset($statusLabels[$sub->status]) ? $statusLabels[$sub->status] : ucfirst($sub->status);
                             $hasFutureAccess = $sub->status === 'cancelled' && Subscriptions::hasAccessValidity($sub);
                             $periodEnd = (!empty($sub->current_period_end) && $sub->current_period_end !== '0000-00-00 00:00:00')
@@ -74,13 +80,13 @@ $statusLabels = [
                             <td><?php echo esc_html($sub->status === 'active' ? $periodEnd : '--'); ?></td>
                             <td><?php echo esc_html($startedAt); ?></td>
                             <td>
-                                <?php if ($sub->status === 'active' && $sub->interval_type !== 'one_time') : ?>
+                                <?php if ($sub->status === 'active' && $sub->interval_type !== 'one_time' && !empty($sub->subscription_id)) : ?>
                                 <div class="bmc-sub-actions">
                                     <button type="button" class="bmc-sub-actions__trigger" aria-label="<?php esc_attr_e('Actions', 'buy-me-coffee'); ?>">
                                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
                                     </button>
                                     <div class="bmc-sub-actions__menu">
-                                        <button type="button" class="bmc-sub-actions__item bmc-sub-actions__item--danger" data-bmc-cancel-sub="<?php echo absint($sub->id); ?>">
+                                        <button type="button" class="bmc-sub-actions__item bmc-sub-actions__item--danger" data-bmc-cancel-sub="<?php echo absint($sub->subscription_id); ?>">
                                             <?php esc_html_e('Cancel subscription', 'buy-me-coffee'); ?>
                                         </button>
                                     </div>
@@ -93,7 +99,7 @@ $statusLabels = [
                 </table>
             </div>
         <?php else : ?>
-            <p class="bmc-account-empty-msg"><?php esc_html_e('No active subscriptions found.', 'buy-me-coffee'); ?></p>
+            <p class="bmc-account-empty-msg"><?php esc_html_e('No active memberships or subscriptions found.', 'buy-me-coffee'); ?></p>
         <?php endif; ?>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "node src/env/production_mode.js && vite build",
     "build:zip": "npm run package",
     "production": "npm run build",
-    "package": "npm run build && mkdir -p builds && rm -f builds/buy-me-coffee.zip && zip -r builds/buy-me-coffee.zip assets buy-me-coffee.php includes index.php languages license.txt readme.txt"
+    "package": "npm run build && mkdir -p builds && rm -f builds/buy-me-coffee.zip && zip -r builds/buy-me-coffee.zip assets buy-me-coffee.php includes index.php languages license.txt readme.txt -x '*/.DS_Store' '__MACOSX/*'"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.0.9",

--- a/src/js/BmcPublic.js
+++ b/src/js/BmcPublic.js
@@ -37,7 +37,6 @@ let BuyMeCoffeeApp = {};
 
     $(window).on('load', function () {
         if (!BuyMeCoffeeApp?.initiated) {
-            console.log('initiating');
             BuyMeCoffeeApp.init();
         }
     });

--- a/src/js/Components/Gateway.vue
+++ b/src/js/Components/Gateway.vue
@@ -94,6 +94,7 @@
 
 <script>
 import { CreditCard, ArrowUpDown, DollarSign } from 'lucide-vue-next';
+import { ElMessage } from 'element-plus';
 import CoffeeLoader from './UI/CoffeeLoader.vue';
 import PageTitle from './UI/PageTitle.vue';
 
@@ -129,8 +130,8 @@ export default {
                     this.stats = response.data.stats;
                 }
             })
-            .catch((error) => {
-                console.log(error);
+            .catch(() => {
+                ElMessage.error('Could not load payment gateways.');
             })
             .always(() => {
                 this.loading = false;

--- a/src/js/Components/Memberships/Memberships.vue
+++ b/src/js/Components/Memberships/Memberships.vue
@@ -20,7 +20,7 @@
       <section v-show="active === 'members'">
         <div class="bmc-card">
           <div class="bmc-card-header">
-            <h3 class="bmc-sc__title">Members with Access</h3>
+            <h3 class="bmc-sc__title">Membership Access</h3>
             <el-input
               v-model="memberSearch"
               placeholder="Search by name or email…"
@@ -30,7 +30,7 @@
             />
           </div>
 
-          <el-table :data="members" style="width:100%" class="bmc-table" v-loading="membersLoading" empty-text="No members with access yet">
+          <el-table :data="members" style="width:100%" class="bmc-table" v-loading="membersLoading" empty-text="No membership access records yet">
             <el-table-column prop="supporters_name" label="Name" min-width="130">
               <template #default="{ row }">
                 <router-link
@@ -459,10 +459,6 @@ function formatPrice(cents) {
 }
 
 function memberRoute(row) {
-  if (row?.subscription_id) {
-    return { name: 'SubscriptionDetail', params: { id: row.subscription_id } };
-  }
-
   if (row?.supporter_id) {
     return { name: 'Supporter', params: { id: row.supporter_id } };
   }

--- a/src/js/Components/Memberships/Memberships.vue
+++ b/src/js/Components/Memberships/Memberships.vue
@@ -20,7 +20,7 @@
       <section v-show="active === 'members'">
         <div class="bmc-card">
           <div class="bmc-card-header">
-            <h3 class="bmc-sc__title">Active Members</h3>
+            <h3 class="bmc-sc__title">Members with Access</h3>
             <el-input
               v-model="memberSearch"
               placeholder="Search by name or email…"
@@ -30,16 +30,18 @@
             />
           </div>
 
-          <el-table :data="members" style="width:100%" class="bmc-table" v-loading="membersLoading" empty-text="No members yet">
+          <el-table :data="members" style="width:100%" class="bmc-table" v-loading="membersLoading" empty-text="No members with access yet">
             <el-table-column prop="supporters_name" label="Name" min-width="130">
               <template #default="{ row }">
                 <router-link
-                  :to="{ name: 'SubscriptionDetail', params: { id: row.subscription_id } }"
+                  v-if="memberRoute(row)"
+                  :to="memberRoute(row)"
                   class="bmc-entity-link"
                   @click.stop
                 >
                   {{ row.supporters_name || 'Anonymous' }}
                 </router-link>
+                <span v-else>{{ row.supporters_name || 'Anonymous' }}</span>
               </template>
             </el-table-column>
             <el-table-column prop="supporters_email" label="Email" min-width="170" />
@@ -57,7 +59,7 @@
             </el-table-column>
             <el-table-column prop="interval_type" label="Billing" width="90">
               <template #default="{ row }">
-                <span class="bmc-text-muted">{{ row.interval_type === 'one_time' ? 'One-time' : (row.interval_type === 'year' ? 'Yearly' : 'Monthly') }}</span>
+                <span class="bmc-text-muted">{{ row.interval_type === 'one_time' ? 'One-time' : (row.interval_type === 'manual' ? 'Manual' : (row.interval_type === 'year' ? 'Yearly' : 'Monthly')) }}</span>
               </template>
             </el-table-column>
             <el-table-column prop="status" label="Status" width="100">
@@ -67,17 +69,18 @@
             </el-table-column>
             <el-table-column width="100" align="center">
               <template #default="{ row }">
-                <el-dropdown trigger="click" @command="(cmd) => handleMemberAction(cmd, row)">
+                <el-dropdown v-if="row.subscription_id" trigger="click" @command="(cmd) => handleMemberAction(cmd, row)">
                   <button class="bmc-actions-btn" type="button">
                     <MoreHorizontal :size="16" />
                   </button>
                   <template #dropdown>
                     <el-dropdown-menu>
-                      <el-dropdown-item command="view_subscription">{{ row.interval_type === 'one_time' ? 'View access' : 'View subscription' }}</el-dropdown-item>
-                      <el-dropdown-item v-if="row.status === 'active' && row.interval_type !== 'one_time'" command="cancel" divided style="color:#dc2626">Cancel membership</el-dropdown-item>
+                      <el-dropdown-item v-if="row.subscription_id" command="view_subscription">View subscription</el-dropdown-item>
+                      <el-dropdown-item v-if="row.status === 'active' && row.access_type === 'subscription' && row.subscription_id" command="cancel" divided style="color:#dc2626">Cancel membership</el-dropdown-item>
                     </el-dropdown-menu>
                   </template>
                 </el-dropdown>
+                <span v-else class="bmc-text-muted">—</span>
               </template>
             </el-table-column>
           </el-table>
@@ -455,6 +458,18 @@ function formatPrice(cents) {
   return (cents / 100).toFixed(2).replace(/\.00$/, '');
 }
 
+function memberRoute(row) {
+  if (row?.subscription_id) {
+    return { name: 'SubscriptionDetail', params: { id: row.subscription_id } };
+  }
+
+  if (row?.supporter_id) {
+    return { name: 'Supporter', params: { id: row.supporter_id } };
+  }
+
+  return null;
+}
+
 async function fetchLevels() {
   const res = await adminGet('get_membership_levels');
   levels.value = res?.data?.levels || [];
@@ -542,8 +557,10 @@ async function confirmDelete(level) {
 
 async function handleMemberAction(command, row) {
   if (command === 'view_subscription') {
+    if (!row.subscription_id) return;
     vm?.$router?.push({ name: 'SubscriptionDetail', params: { id: row.subscription_id } });
   } else if (command === 'cancel') {
+    if (!row.subscription_id) return;
     try {
       await ElMessageBox.confirm(
         `Cancel the membership for "${row.supporters_name || 'this member'}"? This will revoke their access to paid content.`,

--- a/src/js/Components/Supporter.vue
+++ b/src/js/Components/Supporter.vue
@@ -260,6 +260,64 @@
         </div>
       </div>
 
+      <!-- Membership Access -->
+      <div
+        v-if="supporter.membership_access && supporter.membership_access.length"
+        class="bg-white rounded-xl border border-neutral-200 shadow-xs p-6 mb-6"
+      >
+        <h3 class="text-sm font-semibold uppercase tracking-wide mt-0 mb-4" style="color: var(--text-secondary)">
+          Membership Access
+        </h3>
+        <el-table :data="supporter.membership_access" class="w-full">
+          <el-table-column label="Level" min-width="150">
+            <template #default="{ row }">
+              <span class="text-sm font-medium" style="color: var(--text-primary)">
+                {{ row.level_name || '--' }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Billing" min-width="110">
+            <template #default="{ row }">
+              <span class="text-sm" style="color: var(--text-secondary)">
+                {{ formatMembershipBilling(row) }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Access" min-width="140">
+            <template #default="{ row }">
+              <span class="text-sm" style="color: var(--text-primary)">
+                {{ formatAccessPeriod(row) }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Amount" min-width="120">
+            <template #default="{ row }">
+              <span class="text-sm font-medium" style="color: var(--text-primary)">
+                {{ getMembershipAccessAmount(row) }}
+              </span>
+            </template>
+          </el-table-column>
+          <el-table-column label="Status" min-width="110">
+            <template #default="{ row }">
+              <StatusBadge :status="row.status" />
+            </template>
+          </el-table-column>
+          <el-table-column label="" width="120">
+            <template #default="{ row }">
+              <router-link
+                v-if="row.subscription_id"
+                :to="{ name: 'SubscriptionDetail', params: { id: row.subscription_id } }"
+                class="inline-flex items-center gap-1 text-xs font-medium no-underline hover:underline"
+                style="color: var(--color-primary-600)"
+              >
+                View <ExternalLink :size="11" />
+              </router-link>
+              <span v-else class="text-xs" style="color: var(--text-tertiary)">--</span>
+            </template>
+          </el-table-column>
+        </el-table>
+      </div>
+
       <!-- Payment History (all transactions including renewals) -->
       <div
         v-if="supporter.transactions && supporter.transactions.length > 1"
@@ -543,6 +601,33 @@ export default {
     },
     getFormatedAmount(amount, currency) {
       return this.$formatAmount(amount, currency, { empty: '--' });
+    },
+    formatMembershipBilling(row) {
+      if (row.access_type === 'one_time') {
+        return 'One-time';
+      }
+
+      if (row.access_type === 'manual') {
+        return 'Manual';
+      }
+
+      return row.billing_interval === 'year' ? 'Yearly' : 'Monthly';
+    },
+    formatAccessPeriod(row) {
+      if (row.access_type === 'one_time' || row.access_type === 'manual') {
+        return 'Lifetime';
+      }
+
+      if (!row.expires_at || row.expires_at === '0000-00-00 00:00:00') {
+        return '--';
+      }
+
+      return new Date(row.expires_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    },
+    getMembershipAccessAmount(row) {
+      const amount = row.transaction_amount || row.subscription_amount || 0;
+      const currency = row.transaction_currency || row.subscription_currency || this.supporter.currency;
+      return this.getFormatedAmount(amount, currency);
     },
     updateStatus() {
       ElMessageBox.confirm(

--- a/src/js/Editor/gutenBlock.jsx
+++ b/src/js/Editor/gutenBlock.jsx
@@ -1,4 +1,3 @@
-console.log('buymecoffee-gutenberg-block');
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 const {

--- a/src/js/PaymentMethods/stripe-checkout.js
+++ b/src/js/PaymentMethods/stripe-checkout.js
@@ -62,8 +62,8 @@ class StripeCheckout {
                         confirmPayload.subscriptionId = self.subscriptionId;
                     }
 
-                    await jQuery.post(window.buymecoffee_general.ajax_url, confirmPayload);
-                    self.afterPaymentSuccess();
+                    const confirmation = await jQuery.post(window.buymecoffee_general.ajax_url, confirmPayload);
+                    self.afterPaymentSuccess(confirmation?.data || {});
                 } catch (error) {
                     const message = error?.responseJSON?.data?.message || error?.message || 'Payment could not be confirmed. Please try again.';
                     self.showError(message);
@@ -88,15 +88,18 @@ class StripeCheckout {
         this.loader.show('Setting up payment...');
     }
 
-    afterPaymentSuccess() {
+    afterPaymentSuccess(confirmation = {}) {
         const isSubscription = !!this.data?.is_subscription;
         const isMembership = !!this.data?.is_membership;
-        const messageTitle = isSubscription
-            ? "Recurring donation set up successfully"
-            : (isMembership ? "Membership activated" : "Thanks for your contribution");
-        const messageSubtitle = isSubscription
-            ? "Your subscription is active. You can manage everything from your account."
-            : (isMembership ? "Your membership access is active. You can manage everything from your account." : "Your payment was successful. You can view your receipt below.");
+        const isPaid = confirmation.payment_status === 'paid';
+        const accessActive = confirmation.access_active === true || confirmation.access_active === '1';
+        const isActive = isPaid && (!isMembership || accessActive);
+        const messageTitle = isActive
+            ? (isSubscription ? "Recurring donation set up successfully" : (isMembership ? "Membership activated" : "Thanks for your contribution"))
+            : "Payment is processing";
+        const messageSubtitle = isActive
+            ? (isSubscription ? "Your subscription is active. You can manage everything from your account." : (isMembership ? "Your membership access is active. You can manage everything from your account." : "Your payment was successful. You can view your receipt below."))
+            : "Stripe is still confirming this payment. Your access will be available as soon as the payment is completed.";
 
         const receiptContainer = jQuery("<div class='buymecoffee_form_receipt'></div>");
         const receiptCard = jQuery("<div class='bmc-receipt-success'></div>");
@@ -119,7 +122,7 @@ class StripeCheckout {
             actions.append(receiptLink);
         }
 
-        if (isSubscription) {
+        if ((isSubscription || isMembership) && isActive) {
             const accountPageUrl = this.getSafeReceiptUrl(window.buymecoffee_general?.account_page_url);
             if (accountPageUrl) {
                 const accountLink = jQuery('<a></a>')


### PR DESCRIPTION
## What does this PR do and why?

This PR prepares the membership monetization release by moving membership entitlement checks to a dedicated membership access source of truth. It separates one-time/manual lifetime access from recurring subscription access, so one-time membership payments no longer need placeholder subscription rows and recurring access can stay tied to the subscription renewal period.

It also tightens the admin release experience: membership members are listed from `buymecoffee_membership_access`, supporter detail pages show related access records, one-time membership checkout/paywall labels use `Join`, and the production package excludes macOS metadata.

Source branch: `dedicated-access-managements`  
Commits covered: `1247c1d` and `613c9f6`

## Changes

- Added `includes/Models/MembershipAccess.php` to create, update, activate, and resolve membership access records for one-time, manual, and subscription-backed access.
- Added the `buymecoffee_membership_access` migration/backfill path in `includes/Classes/Activator.php`, including schema verification and cache invalidation for existing access metadata.
- Updated Stripe payment handling so one-time membership payments create pending access records, activate access after successful payment, and return membership access state in payment confirmation responses.
- Synced subscription activation, renewal, cancellation, and status changes into membership access rows via `UserManager`, `StripeSubscriptions`, and related payment helpers.
- Updated admin members list to read from `buymecoffee_membership_access` joined with supporters, levels, and subscriptions.
- Added membership access records to the Supporter single page for reviewer/admin visibility.
- Updated one-time membership UI labels so paywall and checkout buttons use `Join`, while recurring membership keeps `Subscribe`.
- Removed frontend debug logs, replaced gateway load debug output with an admin-visible error message, and updated `npm run package` to exclude `.DS_Store`/`__MACOSX`.

## How to test

- Run `rg --files -g '*.php' | xargs -n1 php -l` and confirm all PHP files pass syntax checks.
- Run `npm run build` and confirm Vite builds production assets successfully.
- Run `npm run package` and confirm `builds/buy-me-coffee.zip` is created.
- Run `unzip -l builds/buy-me-coffee.zip | rg "\\.DS_Store|__MACOSX"` and confirm no output.
- In WP-CLI, verify `wp_buymecoffee_membership_access` exists with `supporter_id`, `wp_user_id`, `level_id`, `transaction_id`, `subscription_id`, `access_type`, `status`, `starts_at`, and `expires_at`.
- In WP-CLI, verify the membership members query returns rows from membership access; local check returned `16` rows, including `2` one-time and `14` subscription records.
- In WP-CLI, verify supporter detail loads related membership access; local check returned one access row for supporter `108` with no DB error.
- In WP-CLI, verify access resolution for one-time, active recurring, and cancelled-but-still-valid recurring memberships returns the expected active level IDs.

## Anything the reviewer should know?

- This PR adds a new table and migration/backfill path. Please review migration behavior carefully because production upgrades depend on it.
- The local checks covered database smoke tests and production builds, but did not run a live external Stripe or PayPal payment round-trip. A staging gateway transaction should be run before release.
- Generated build assets are not committed here; the release package is generated via `npm run package`.
